### PR TITLE
source-hubspot: select streams based on subscription type

### DIFF
--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/source.py
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/source.py
@@ -78,6 +78,7 @@ class SourceHubspot(AbstractSource):
     def streams(self, config: Mapping[str, Any]) -> List[Stream]:
         credentials = config.get("credentials", {})
         common_params = self.get_common_params(config=config)
+
         streams = [
             Campaigns(**common_params),
             Companies(**common_params),
@@ -93,19 +94,24 @@ class SourceHubspot(AbstractSource):
             EngagementsMeetings(**common_params),
             EngagementsNotes(**common_params),
             EngagementsTasks(**common_params),
-            FeedbackSubmissions(**common_params),
             Forms(**common_params),
             FormSubmissions(**common_params),
             LineItems(**common_params),
-            MarketingEmails(**common_params),
             Owners(**common_params),
             Products(**common_params),
             PropertyHistory(**common_params),
             SubscriptionChanges(**common_params),
             Tickets(**common_params),
             TicketPipelines(**common_params),
-            Workflows(**common_params),
         ]
+
+        if config.get("subscription_type", "starter") == "pro":
+            pro_streams = [
+                FeedbackSubmissions(**common_params),
+                MarketingEmails(**common_params),
+                Workflows(**common_params),
+            ]
+            streams.extend(pro_streams)
 
         credentials_title = credentials.get("credentials_title")
         if credentials_title == "API Key Credentials":

--- a/airbyte-integrations/connectors/source-hubspot/source_hubspot/spec.yaml
+++ b/airbyte-integrations/connectors/source-hubspot/source_hubspot/spec.yaml
@@ -8,6 +8,15 @@ connectionSpecification:
     - credentials
   additionalProperties: true
   properties:
+    subscription_type:
+      type: string
+      title: Your HubSpot account subscription type
+      description: >-
+        Some streams are only available to certain subscription packages, we use this information to select which streams to pull data from.
+      enum:
+        - starter
+        - pro
+      default: starter
     start_date:
       type: string
       title: Start Date

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/conftest.py
@@ -37,6 +37,15 @@ def config_fixture():
     return {"start_date": "2021-01-10T00:00:00Z", "credentials": {"credentials_title": "API Key Credentials", "api_key": "test_api_key"}}
 
 
+@pytest.fixture(name="config_pro")
+def config_pro_fixture():
+    return {
+        "start_date": "2021-01-10T00:00:00Z",
+        "credentials": {"credentials_title": "API Key Credentials", "api_key": "test_api_key"},
+        "subscription_type": "pro",
+    }
+
+
 @pytest.fixture(name="some_credentials")
 def some_credentials_fixture():
     return {"credentials_title": "API Key Credentials", "api_key": "wrong_key"}

--- a/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
+++ b/airbyte-integrations/connectors/source-hubspot/unit_tests/test_source.py
@@ -65,6 +65,12 @@ def test_check_connection_exception(config):
 def test_streams(config):
     streams = SourceHubspot().streams(config)
 
+    assert len(streams) == 24
+
+
+def test_pro_streams(config_pro):
+    streams = SourceHubspot().streams(config_pro)
+
     assert len(streams) == 27
 
 


### PR DESCRIPTION
- Introduce a new configuration `subscription_type` with default value `starter` and a possible value of `pro` which will determine how many streams are available to the user.
- The `pro` subscription has access to 3 additional streams at this point.