### PR TITLE
source-facebook-marketing: fix config enum types to be string

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/source.py
@@ -67,8 +67,20 @@ class SourceFacebookMarketing(AbstractSource):
         )
         streams = [
             AdAccount(api=api),
-            AdSets(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted, page_size=config.page_size),
-            Ads(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted, page_size=config.page_size),
+            AdSets(
+                api=api,
+                start_date=config.start_date,
+                end_date=config.end_date,
+                include_deleted=config.include_deleted,
+                page_size=config.page_size,
+            ),
+            Ads(
+                api=api,
+                start_date=config.start_date,
+                end_date=config.end_date,
+                include_deleted=config.include_deleted,
+                page_size=config.page_size,
+            ),
             AdCreatives(api=api, fetch_thumbnail_images=config.fetch_thumbnail_images, page_size=config.page_size),
             AdsInsights(page_size=config.page_size, **insights_args),
             AdsInsightsAgeAndGender(page_size=config.page_size, **insights_args),
@@ -77,10 +89,34 @@ class SourceFacebookMarketing(AbstractSource):
             AdsInsightsDma(page_size=config.page_size, **insights_args),
             AdsInsightsPlatformAndDevice(page_size=config.page_size, **insights_args),
             AdsInsightsActionType(page_size=config.page_size, **insights_args),
-            Campaigns(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted, page_size=config.page_size),
-            Images(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted, page_size=config.page_size),
-            Videos(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted, page_size=config.page_size),
-            Activities(api=api, start_date=config.start_date, end_date=config.end_date, include_deleted=config.include_deleted, page_size=config.page_size),
+            Campaigns(
+                api=api,
+                start_date=config.start_date,
+                end_date=config.end_date,
+                include_deleted=config.include_deleted,
+                page_size=config.page_size,
+            ),
+            Images(
+                api=api,
+                start_date=config.start_date,
+                end_date=config.end_date,
+                include_deleted=config.include_deleted,
+                page_size=config.page_size,
+            ),
+            Videos(
+                api=api,
+                start_date=config.start_date,
+                end_date=config.end_date,
+                include_deleted=config.include_deleted,
+                page_size=config.page_size,
+            ),
+            Activities(
+                api=api,
+                start_date=config.start_date,
+                end_date=config.end_date,
+                include_deleted=config.include_deleted,
+                page_size=config.page_size,
+            ),
         ]
 
         return self._update_insights_streams(insights=config.custom_insights, default_args=insights_args, streams=streams)

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/spec.py
@@ -15,9 +15,13 @@ from pydantic import BaseModel, Field, PositiveInt
 logger = logging.getLogger("airbyte")
 
 
-ValidFields = Enum("ValidEnums", AdsInsights.Field.__dict__)
-ValidBreakdowns = Enum("ValidBreakdowns", AdsInsights.Breakdowns.__dict__)
-ValidActionBreakdowns = Enum("ValidActionBreakdowns", AdsInsights.ActionBreakdowns.__dict__)
+class StrEnum(str, Enum):
+    pass
+
+
+ValidFields = StrEnum("ValidEnums", AdsInsights.Field.__dict__)
+ValidBreakdowns = StrEnum("ValidBreakdowns", AdsInsights.Breakdowns.__dict__)
+ValidActionBreakdowns = StrEnum("ValidActionBreakdowns", AdsInsights.ActionBreakdowns.__dict__)
 DATE_TIME_PATTERN = "^[0-9]{4}-[0-9]{2}-[0-9]{2}T[0-9]{2}:[0-9]{2}:[0-9]{2}Z$"
 
 
@@ -112,10 +116,7 @@ class ConnectorConfig(BaseConfig):
     access_token: str = Field(
         title="Access Token",
         order=3,
-        description=(
-            "The value of the access token generated. "
-            'See the docs for more information: https://go.estuary.dev/OzUqlE'
-        ),
+        description=("The value of the access token generated. " "See the docs for more information: https://go.estuary.dev/OzUqlE"),
         airbyte_secret=True,
     )
 

--- a/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_streams.py
+++ b/airbyte-integrations/connectors/source-facebook-marketing/source_facebook_marketing/streams/base_streams.py
@@ -37,7 +37,7 @@ class FBMarketingStream(Stream, ABC):
     # entity prefix for `include_deleted` filter, it usually matches singular version of stream name
     entity_prefix = None
 
-    def __init__(self, api: "API", include_deleted: bool = False, page_size = 100, **kwargs):
+    def __init__(self, api: "API", include_deleted: bool = False, page_size=100, **kwargs):
         super().__init__(**kwargs)
         self._api = api
         self.page_size = page_size if page_size is not None else 100


### PR DESCRIPTION
- Some of the configuration parameters are arrays of enums, and those enums did not have any specific type associated with them, because they were dynamically created.
- This PR ensures that the enums are considered to be of type string

![image](https://user-images.githubusercontent.com/2807772/170451189-917074f8-69c2-4ee5-841d-bd69006c0ed9.png)
