### PR TITLE
oauth: use triple-braces in templates

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-bing-ads/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
   "provider": "microsoft",
-  "authUrlTemplate": "https://login.microsoftonline.com/{{ config.tenant_id }}/oauth2/v2.0/authorize?client_id={{ urlencode client_id }}&scope=openid%20profile%20https://ads.microsoft.com/msads.manage%20offline_access&response_type=code&redirect_uri={{ urlencode redirect_uri }}&state={{ urlencode state }}&response_mode=query",
+  "authUrlTemplate": "https://login.microsoftonline.com/{{{ config.tenant_id }}}/oauth2/v2.0/authorize?client_id={{{ urlencode client_id }}}&scope=openid%20profile%20https://ads.microsoft.com/msads.manage%20offline_access&response_type=code&redirect_uri={{{ urlencode redirect_uri }}}&state={{{ urlencode state }}}&response_mode=query",
   "accessTokenUrlTemplate": "https://login.microsoftonline.com/common/oauth2/v2.0/token",
-  "accessTokenBody": "client_id={{ urlencode client_id }}&scope=openid%20profile%20https://ads.microsoft.com/msads.manage%20offline_access&code={{ urlencode code }}&grant_type=authorization_code&redirect_uri={{ urlencode redirect_uri }}&client_secret={{ urlencode client_secret }}",
+  "accessTokenBody": "client_id={{{ urlencode client_id }}}&scope=openid%20profile%20https://ads.microsoft.com/msads.manage%20offline_access&code={{{ urlencode code }}}&grant_type=authorization_code&redirect_uri={{{ urlencode redirect_uri }}}&client_secret={{{ urlencode client_secret }}}",
   "accessTokenHeaders": "{\"content-type\": \"application/x-www-form-urlencoded\"}",
   "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/oauth2.patch.json
@@ -1,7 +1,7 @@
 {
   "provider": "facebook",
-  "authUrlTemplate": "https://www.facebook.com/v12.0/dialog/oauth?client_id={{ urlencode client_id }}&redirect_uri={{ urlencode redirect_uri }}&state={{ urlencode state }}&scope=ads_management,ads_read,read_insights,business_management",
-  "accessTokenUrlTemplate": "https://graph.facebook.com/v12.0/oauth/access_token?client_id={{ urlencode client_id }}&client_secret={{ urlencode client_secret }}&grant_type=fb_exchange_token&fb_exchange_token={{ urlencode code }}",
+  "authUrlTemplate": "https://www.facebook.com/v12.0/dialog/oauth?client_id={{{ urlencode client_id }}}&redirect_uri={{{ urlencode redirect_uri }}}&state={{{ urlencode state }}}&scope=ads_management,ads_read,read_insights,business_management",
+  "accessTokenUrlTemplate": "https://graph.facebook.com/v12.0/oauth/access_token?client_id={{{ urlencode client_id }}}&client_secret={{{ urlencode client_secret }}}&grant_type=fb_exchange_token&fb_exchange_token={{{ urlencode code }}}",
   "accessTokenBody": "",
   "accessTokenHeaders": "",
   "accessTokenResponseMap": "{\"access_token\": \"/access_token\"}"

--- a/airbyte-integrations/connectors/source-github/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-github/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
   "provider": "github",
-  "authUrlTemplate": "https://github.com/login/oauth/authorize?client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&scope=repo%20read:org%20read:repo_hook%20read:user%20read:discussion%20workflow&state={{ state }}",
+  "authUrlTemplate": "https://github.com/login/oauth/authorize?client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&scope=repo%20read:org%20read:repo_hook%20read:user%20read:discussion%20workflow&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://github.com/login/oauth/access_token",
-  "accessTokenBody": "{\"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+  "accessTokenBody": "{\"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
   "accessTokenHeaders": "{\"Accept\": \"application/json\"}",
   "accessTokenResponseMap": "{\"access_token\": \"/access_token\"}"
 }

--- a/airbyte-integrations/connectors/source-google-ads/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-google-ads/oauth2.patch.json
@@ -1,7 +1,7 @@
 {
   "provider": "google",
-  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&scope=https://www.googleapis.com/auth/adwords&state={{ state }}",
+  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&response_type=code&scope=https://www.googleapis.com/auth/adwords&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
-  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
   "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/oauth2.patch.json
@@ -1,7 +1,7 @@
 {
   "provider": "google",
-  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&scope=https://www.googleapis.com/auth/analytics.readonly&state={{ state }}",
+  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&response_type=code&scope=https://www.googleapis.com/auth/analytics.readonly&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
-  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
   "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-google-analytics-v4/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/oauth2.patch.json
@@ -1,7 +1,7 @@
 {
   "provider": "google",
-  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&scope=https://www.googleapis.com/auth/analytics.readonly&state={{ state }}",
+  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&response_type=code&scope=https://www.googleapis.com/auth/analytics.readonly&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
-  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
   "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-google-search-console/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-google-search-console/oauth2.patch.json
@@ -1,7 +1,7 @@
 {
   "provider": "google",
-  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&scope=https://www.googleapis.com/auth/webmasters.readonly&state={{ state }}",
+  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&response_type=code&scope=https://www.googleapis.com/auth/webmasters.readonly&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
-  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
   "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-google-sheets/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-google-sheets/oauth2.patch.json
@@ -1,7 +1,7 @@
 {
   "provider": "google",
-  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&scope=https://www.googleapis.com/auth/spreadsheets.readonly https://www.googleapis.com/auth/drive.readonly&state={{ state }}",
+  "authUrlTemplate": "https://accounts.google.com/o/oauth2/auth?access_type=offline&prompt=consent&client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&response_type=code&scope=https://www.googleapis.com/auth/spreadsheets.readonly https://www.googleapis.com/auth/drive.readonly&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://oauth2.googleapis.com/token",
-  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{ client_id }}\", \"client_secret\": \"{{ client_secret }}\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+  "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"client_id\": \"{{{ client_id }}}\", \"client_secret\": \"{{{ client_secret }}}\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
   "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-hubspot/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-hubspot/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
     "provider": "hubspot",
-    "authUrlTemplate": "https://app.hubspot.com/oauth/authorize?client_id={{ client_id }}&scope=forms%20files%20tickets%20e-commerce%20sales-email-read%20forms-uploaded-files%20crm.lists.read%20crm.objects.contacts.read%20files.ui_hidden.read%20crm.schemas.contacts.read%20crm.objects.companies.read%20crm.objects.deals.read%20crm.schemas.companies.read%20crm.schemas.deals.read%20crm.objects.owners.read&optional_scope=content%20automation%20crm.objects.feedback_submissions.read&redirect_uri={{ redirect_uri }}&response_type=code&state={{ state }}",
+    "authUrlTemplate": "https://app.hubspot.com/oauth/authorize?client_id={{{ client_id }}}&scope=forms%20files%20tickets%20e-commerce%20sales-email-read%20forms-uploaded-files%20crm.lists.read%20crm.objects.contacts.read%20files.ui_hidden.read%20crm.schemas.contacts.read%20crm.objects.companies.read%20crm.objects.deals.read%20crm.schemas.companies.read%20crm.schemas.deals.read%20crm.objects.owners.read&optional_scope=content%20automation%20crm.objects.feedback_submissions.read&redirect_uri={{{ redirect_uri }}}&response_type=code&state={{{ state }}}",
     "accessTokenUrlTemplate": "https://api.hubapi.com/oauth/v1/token",
-    "accessTokenBody": "grant_type=authorization_code&client_id={{ urlencode client_id }}&client_secret={{ urlencode client_secret }}&redirect_uri={{ urlencode redirect_uri }}&code={{ urlencode code }}",
+    "accessTokenBody": "grant_type=authorization_code&client_id={{{ urlencode client_id }}}&client_secret={{{ urlencode client_secret }}}&redirect_uri={{{ urlencode redirect_uri }}}&code={{{ urlencode code }}}",
     "accessTokenHeaders": "{\"content-type\": \"application/x-www-form-urlencoded\"}",
     "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-intercom/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-intercom/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
   "provider": "intercom",
-  "authUrlTemplate": "https://app.intercom.com/oauth?client_id={{ urlencode client_id }}&state={{ urlencode state }}",
+  "authUrlTemplate": "https://app.intercom.com/oauth?client_id={{{ urlencode client_id }}}&state={{{ urlencode state }}}",
   "accessTokenUrlTemplate": "https://api.intercom.io/auth/eagle/token",
-  "accessTokenBody": "client_id={{ urlencode client_id }}&client_secret={{ urlencode client_secret }}&code={{ urlencode code }}",
+  "accessTokenBody": "client_id={{{ urlencode client_id }}}&client_secret={{{ urlencode client_secret }}}&code={{{ urlencode code }}}",
   "accessTokenHeaders": "{\"content-type\": \"application/x-www-form-urlencoded\"}",
   "accessTokenResponseMap": "{\"access_token\": \"/token\"}"
 }

--- a/airbyte-integrations/connectors/source-linkedin-ads/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-linkedin-ads/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
   "provider": "linkedin",
-  "authUrlTemplate": "https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&scope=r_emailaddress%20r_liteprofile%20r_ads%20r_ads_reporting%20r_organization_social&state={{ state }}",
+  "authUrlTemplate": "https://www.linkedin.com/oauth/v2/authorization?response_type=code&client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&scope=r_emailaddress%20r_liteprofile%20r_ads%20r_ads_reporting%20r_organization_social&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://www.linkedin.com/oauth/v2/accessToken",
-  "accessTokenBody": "grant_type=authorization_code&client_id={{ urlencode client_id }}&client_secret={{ urlencode client_secret }}&redirect_uri={{ urlencode redirect_uri }}&code={{ urlencode code }}",
+  "accessTokenBody": "grant_type=authorization_code&client_id={{{ urlencode client_id }}}&client_secret={{{ urlencode client_secret }}}&redirect_uri={{{ urlencode redirect_uri }}}&code={{{ urlencode code }}}",
   "accessTokenHeaders": "{\"content-type\": \"application/x-www-form-urlencoded\"}",
   "accessTokenResponseMap": "{\"refresh_token\": \"/refresh_token\"}"
 }

--- a/airbyte-integrations/connectors/source-mailchimp/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-mailchimp/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
   "provider": "mailchimp",
-  "authUrlTemplate": "https://login.mailchimp.com/oauth2/authorize?response_type=code&client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&state={{ state }}",
+  "authUrlTemplate": "https://login.mailchimp.com/oauth2/authorize?response_type=code&client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&state={{{ state }}}",
   "accessTokenUrlTemplate": "https://login.mailchimp.com/oauth2/token",
-  "accessTokenBody": "grant_type=authorization_code&client_id={{ urlencode client_id }}&client_secret={{ urlencode client_secret }}&redirect_uri={{ urlencode redirect_uri }}&code={{ urlencode code }}",
+  "accessTokenBody": "grant_type=authorization_code&client_id={{{ urlencode client_id }}}&client_secret={{{ urlencode client_secret }}}&redirect_uri={{{ urlencode redirect_uri }}}&code={{{ urlencode code }}}",
   "accessTokenHeaders": "{\"content-type\": \"application/x-www-form-urlencoded\"}",
   "accessTokenResponseMap": "{\"access_token\": \"/access_token\"}"
 }

--- a/airbyte-integrations/connectors/source-notion/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-notion/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
  "provider": "notion",
- "authUrlTemplate": "https://api.notion.com/v1/oauth/authorize?client_id={{ client_id }}&redirect_uri={{ redirect_uri }}&response_type=code&owner=user&state={{ state }}",
+ "authUrlTemplate": "https://api.notion.com/v1/oauth/authorize?client_id={{{ client_id }}}&redirect_uri={{{ redirect_uri }}}&response_type=code&owner=user&state={{{ state }}}",
  "accessTokenUrlTemplate": "https://api.notion.com/v1/oauth/token",
- "accessTokenHeaders": "{\"Authorization\": \"Basic {{ basicauth client_id client_secret }}\", \"Content-Type\": \"application/json\"}",
- "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"redirect_uri\": \"{{ redirect_uri }}\", \"code\": \"{{ code }}\"}",
+ "accessTokenHeaders": "{\"Authorization\": \"Basic {{{ basicauth client_id client_secret }}}\", \"Content-Type\": \"application/json\"}",
+ "accessTokenBody": "{\"grant_type\": \"authorization_code\", \"redirect_uri\": \"{{{ redirect_uri }}}\", \"code\": \"{{{ code }}}\"}",
  "accessTokenResponseMap": "{\"access_token\": \"/access_token\"}"
 }

--- a/airbyte-integrations/connectors/source-surveymonkey/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-surveymonkey/oauth2.patch.json
@@ -1,8 +1,8 @@
 {
   "provider": "surveymonkey",
-  "authUrlTemplate": "https://api.surveymonkey.com/oauth/authorize?client_id={{ urlencode client_id }}&redirect_uri={{ urlencode redirect_uri }}&response_type=code&state={{ urlencode state }}",
+  "authUrlTemplate": "https://api.surveymonkey.com/oauth/authorize?client_id={{{ urlencode client_id }}}&redirect_uri={{{ urlencode redirect_uri }}}&response_type=code&state={{{ urlencode state }}}",
   "accessTokenUrlTemplate": "https://api.surveymonkey.com/oauth/token",
-  "accessTokenBody": "grant_type=authorization_code&client_id={{ urlencode client_id }}&client_secret={{ urlencode client_secret }}&redirect_uri={{ urlencode redirect_uri }}&code={{ urlencode code }}",
+  "accessTokenBody": "grant_type=authorization_code&client_id={{{ urlencode client_id }}}&client_secret={{{ urlencode client_secret }}}&redirect_uri={{{ urlencode redirect_uri }}}&code={{{ urlencode code }}}",
   "accessTokenHeaders": "{\"content-type\": \"application/x-www-form-urlencoded\"}",
   "accessTokenResponseMap": "{\"access_token\": \"/access_token\"}"
 }

--- a/airbyte-integrations/connectors/source-tiktok-marketing/oauth2.patch.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/oauth2.patch.json
@@ -1,7 +1,7 @@
 {
   "provider": "tiktok",
-  "authUrlTemplate": "https://ads.tiktok.com/marketing_api/auth?app_id={{ urlencode client_id }}&redirect_uri={{ urlencode redirect_uri }}&response_type=code&state={{ urlencode state }}",
-  "accessTokenUrlTemplate": "https://ads.tiktok.com/open_api/v1.2/oauth2/access_token/?app_id={{ urlencode client_id }}&secret={{ urlencode client_secret }}&auth_code={{ urlencode code }}&grant_type=authorization_code",
+  "authUrlTemplate": "https://ads.tiktok.com/marketing_api/auth?app_id={{{ urlencode client_id }}}&redirect_uri={{{ urlencode redirect_uri }}}&response_type=code&state={{{ urlencode state }}}",
+  "accessTokenUrlTemplate": "https://ads.tiktok.com/open_api/v1.2/oauth2/access_token/?app_id={{{ urlencode client_id }}}&secret={{{ urlencode client_secret }}}&auth_code={{{ urlencode code }}}&grant_type=authorization_code",
   "accessTokenBody": "",
   "accessTokenResponseMap": "{\"access_token\": \"/data/access_token\"}"
 }


### PR DESCRIPTION
Using triple-braces which do not HTML-escape their value in mustache and handlebars. With Handlebars we have been using a global option to turn off this HTML-escaping, but with mustache there doesn't seem to be this option so we are going to use triple-braces.