### PR TITLE
spec description updates (various)

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/.dockerignore
+++ b/airbyte-integrations/connectors/source-amazon-ads/.dockerignore
@@ -1,4 +1,5 @@
 *
+!*.patch.json
 !Dockerfile
 !main.py
 !source_amazon_ads

--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -9,6 +9,8 @@ COPY main.py ./
 COPY setup.py ./
 RUN pip install .
 
+COPY *.patch.json ./
+
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]

--- a/airbyte-integrations/connectors/source-amazon-ads/spec.patch.json
+++ b/airbyte-integrations/connectors/source-amazon-ads/spec.patch.json
@@ -1,0 +1,10 @@
+{
+    "properties": {
+        "region": {
+            "description": "Region to pull data from (EU/NA/FE). See the docs for more details https://go.estuary.dev/8Ra66M"
+        },
+        "start_date": {
+            "description": "Date from which to start collecting reports, in YYYY-MM-DD format. Shouldn’t be more than 60 days in the past."
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-bing-ads/spec.patch.json
+++ b/airbyte-integrations/connectors/source-bing-ads/spec.patch.json
@@ -12,6 +12,9 @@
     "tenant_id": {
       "airbyte_secret": false
     },
+    "developer_token": {
+      "description": "Developer token associated with user. See the docs for more information: https://go.estuary.dev/BpBK1T"
+    },
     "credentials": {
       "type": "object",
       "description": "",

--- a/airbyte-integrations/connectors/source-exchange-rates/spec.patch.json
+++ b/airbyte-integrations/connectors/source-exchange-rates/spec.patch.json
@@ -4,10 +4,10 @@
       "description": "The date in the format YYYY-MM-DD. Data will begin from this date."
     },
     "access_key": {
-      "description": "Your API Access Key. See this article to generate one https://exchangeratesapi.io/documentation/. The key is case sensitive."
+      "description": "Your API Access Key. The key is case sensitive. See this article to generate one: https://go.estuary.dev/K4HVxT"
     },
     "base": {
-      "description": "ISO reference currency. See the documentation https://www.ecb.europa.eu/stats/policy_and_exchange_rates/euro_reference_exchange_rates/html/index.en.html."
+      "description": "ISO reference currency. See the documentation: https://go.estuary.dev/duDtKm"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-facebook-marketing/spec.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/spec.patch.json
@@ -17,7 +17,7 @@
     },
     "credentials": {
       "title": "Authentication",
-      "description": "Choose how to authenticate to Facebook",
+      "description": "Choose how to authenticate to Facebook.",
       "type": "object",
       "discriminator": {
         "propertyName": "auth_type"
@@ -33,7 +33,7 @@
           "auth_type": {
               "type": "string",
               "title": "Credentials",
-              "description": "Name of the credentials",
+              "description": "Authentication Method",
               "const": "OAuth Credentials",
               "default": "OAuth Credentials",
               "order": 0
@@ -57,7 +57,7 @@
           "auth_type": {
               "type": "string",
               "title": "Credentials",
-              "description": "Name of the credentials",
+              "description": "Authentication Method",
               "const": "Access Token",
               "default": "Access Token",
               "order": 0

--- a/airbyte-integrations/connectors/source-facebook-marketing/spec.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/spec.patch.json
@@ -6,6 +6,12 @@
           "insights_lookback_window": {
             "minimum": 1,
             "mininum": null
+          },
+          "page_size": {
+            "description": "Page size used when sending requests to Facebook API to specify number of records per page when response has pagination. You won't need to set this field for most use cases."
+          },
+          "max_batch_size": {
+            "description": "Maximum batch size used when sending batch requests to Facebook API. You won't need to set this field for most use cases."
           }
         }
       }

--- a/airbyte-integrations/connectors/source-github/spec.patch.json
+++ b/airbyte-integrations/connectors/source-github/spec.patch.json
@@ -21,6 +21,7 @@
     },
     "page_size_for_large_streams": {
       "title": "Page size for large streams (Optional)",
+      "description": "The GitHub connector contains several streams with a large amount of data. The page size of such streams depends on the size of your repository. We recommended that you specify values between 10 and 30.",
       "order": 3
     },
     "credentials": {

--- a/airbyte-integrations/connectors/source-google-ads/spec.patch.json
+++ b/airbyte-integrations/connectors/source-google-ads/spec.patch.json
@@ -39,18 +39,18 @@
         "required": ["query", "table_name"],
         "properties": {
           "query": {
-            "description": "A custom defined GAQL query for building the report. Should not contain segments.date expression because it is used by incremental streams. See Google's query builder for more informa tion: https://developers.google.com/google-ads/api/fields/v11/overview_query_builder"
+            "description": "A custom defined GAQL query for building the report. Should not contain segments.date expression. See Google's documentation for more information: https://go.estuary.dev/bhYgzb"
           }
         }
       }
     },
     "login_customer_id": {
       "title": "Login Customer ID for Managed Accounts (Optional)",
-      "description": "If your access to the customer account is through a manager account, this field is required and must be set to the customer ID of the manager account (10-digit number without dashes). Moreinformation about this field you can see here: https://developers.google.com/google-ads/api/docs/concepts/call-structure#cid"
+      "description": "If your access to the customer account is through a manager account, this field is required and must be set to the customer ID of the manager account (10-digit number without dashes). See the docs for more information: https://go.estuary.dev/q3rQAD"
     },
     "conversion_window_days": {
       "title": "Conversion Window (Optional)",
-      "description": "A conversion window is the period of time after an ad interaction (such as an ad click or video view) during which a conversion, such as a purchase, is recorded in Google Ads. For more information, see Google's docs: https://support.google.com/google-ads/answer/3123169?hl=en"
+      "description": "A conversion window is the period of time after an ad interaction (such as an ad click or video view) during which a conversion, such as a purchase, is recorded in Google Ads. For more information, see Google's docs: https://go.estuary.dev/TSbFyk"
     }
   }
 }

--- a/airbyte-integrations/connectors/source-google-analytics-v4/spec.patch.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/spec.patch.json
@@ -7,7 +7,7 @@
       "description": "A JSON array describing the custom reports you want to sync from GA. Check out the docs to get more information about this field: https://go.estuary.dev/6PgxMK"
     },
     "window_in_days": {
-      "description": "The amount of days each stream slice would consist of beginning from start_date. Bigger the value - faster the fetch. (Min=1, as for a Day; Max=364, as for a Year)."
+      "description": "Number of days each read will cover, beginning at the start date. Choose a value between 1 (one day) and 364 (one year)."
     }
   }
 }

--- a/airbyte-integrations/connectors/source-google-search-console/spec.patch.json
+++ b/airbyte-integrations/connectors/source-google-search-console/spec.patch.json
@@ -62,7 +62,7 @@
             "service_account_info": {
               "title": "Service Account JSON Key",
               "type": "string",
-              "description": "The JSON key of the service account to use for authorization. Read more <a href=\"https://cloud.google.com/iam/docs/creating-managing-service-account-keys\">here</a>.",
+              "description": "The JSON key of the service account to use for authorization. Read more in the docs: https://go.estuary.dev/MdCBX1",
               "examples": [
                 "{ \"type\": \"service_account\", \"project_id\": YOUR_PROJECT_ID, \"private_key_id\": YOUR_PRIVATE_KEY, ... }"
               ],

--- a/airbyte-integrations/connectors/source-google-search-console/spec.patch.json
+++ b/airbyte-integrations/connectors/source-google-search-console/spec.patch.json
@@ -2,6 +2,12 @@
   "required": ["site_urls", "start_date", "credentials"],
   "properties": {
     "authorization": null,
+    "site_urls": {
+      "description": "The URLs of the website property attached to your GSC account. See the docs for more information: https://go.estuary.dev/jp3e13"
+    },
+    "custom_reports": {
+      "description": "A JSON array describing the custom reports you want to sync from Google Search Console. See the docs for more information: https://go.estuary.dev/6VN40S"
+    },
     "credentials": {
       "type": "object",
       "title": "Authentication Type",

--- a/airbyte-integrations/connectors/source-hubspot/spec.patch.json
+++ b/airbyte-integrations/connectors/source-hubspot/spec.patch.json
@@ -71,7 +71,7 @@
                     },
                     "api_key": {
                         "title": "API key",
-                        "description": "HubSpot API Key. See the Hubspot docs if you need help finding this key: https://knowledge.hubspot.com/integrations/how-do-i-get-my-hubspot-api-key",
+                        "description": "HubSpot API Key. See the Hubspot docs if you need help finding this key: https://go.estuary.dev/Sg8JDC",
                         "type": "string",
                         "airbyte_secret": true
                     }
@@ -94,7 +94,7 @@
                     },
                     "access_token": {
                         "title": "Access token",
-                        "description": "HubSpot Access token. See the <a href=\"https://developers.hubspot.com/docs/api/private-apps\">Hubspot docs</a> if you need help finding this token.",
+                        "description": "HubSpot Access token. See the docs if you need help finding this token: https://go.estuary.dev/XSVhJy.",
                         "type": "string",
                         "airbyte_secret": true
                     }

--- a/airbyte-integrations/connectors/source-notion/spec.patch.json
+++ b/airbyte-integrations/connectors/source-notion/spec.patch.json
@@ -55,7 +55,7 @@
             },
             "token": {
               "title": "Access Token",
-              "description": "Notion API access token, see the docs for more information https://developers.notion.com/docs/authorization",
+              "description": "Notion API access token, see the docs for more information: https://go.estuary.dev/u5BKFR",
               "type": "string",
               "airbyte_secret": true
             }

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -9,6 +9,8 @@ COPY main.py ./
 COPY setup.py ./
 RUN pip install .
 
+COPY spec.patch.json ./
+
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
 COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]

--- a/airbyte-integrations/connectors/source-stripe/spec.patch.json
+++ b/airbyte-integrations/connectors/source-stripe/spec.patch.json
@@ -1,0 +1,10 @@
+{
+    "properties": {
+        "account_id": {
+            "description": "Your Stripe account ID (starts with acct_). Find yours here: https://go.estuary.dev/t7DgTg"
+        },
+        "client_secret": {
+            "description": "Stripe API key (usually starts with sk_live_). Find yours here: https://go.estuary.dev/t7DgTg"
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-tiktok-marketing/spec.patch.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/spec.patch.json
@@ -73,6 +73,7 @@
         ]
     },
     "report_granularity": {
+      "description":  "The granularity used for aggregating performance data in reports. See the docs: https://go.estuary.dev/umRj4Q",
       "airbyte_hidden": null
     }
   }

--- a/airbyte-integrations/connectors/source-tiktok-marketing/spec.patch.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/spec.patch.json
@@ -55,7 +55,7 @@
                     },
                     "advertiser_id": {
                         "title": "Advertiser ID",
-                        "description": "The Advertiser ID which generated for the developer's Sandbox application.",
+                        "description": "The Advertiser ID generated for your Sandbox application.",
                         "type": "string"
                     },
                     "access_token": {


### PR DESCRIPTION
Includes suggested updates to spec descriptions across various connectors for readability and improved UX. 

Mostly these are:
* Adding branded shortlinks
* Removing HTML
* Punctuation, capitalization, and grammar changes

(I recently updated the [guide in the connectors repo](https://github.com/estuary/connectors/blob/main/config_schema_guidelines.md) to include more structured guidelines around description going forward). 

**A few more recommended changes** (Didn't do these because these connectors don't have spec patch files and I wasn't feeling confident adding them):

SOURCE-AMAZON-ADS
* Region: replace link with https://go.estuary.dev/8Ra66M
* Start date: recommend rewording as “Date from which to start collecting reports, in YYYY-MM-DD format. Shouldn’t be more than 60 days in the past.”

SOURCE-STRIPE
* Account ID: missing close parentheses, and an Estuary shortlink. Should say: “Your Stripe account ID (starts with `acct_`). Find yours here: https://go.estuary.dev/t7DgTg"
* Secret key: Same issue, missing close parentheses and estuary shortlink, should say “Stripe API key (usually starts with `sk_live_`). Find yours here: https://go.estuary.dev/t7DgTg” 
