### PR TITLE
facebook: remove all format: date-time from facebook streams

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/activities.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/activities.patch.json
@@ -1,0 +1,7 @@
+{
+    "properties": {
+        "event_time": {
+            "format": null
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/ad_account.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/ad_account.patch.json
@@ -1,0 +1,7 @@
+{
+    "properties": {
+        "created_time": {
+            "format": null
+        }
+    }
+}

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/ad_creatives.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/ad_creatives.patch.json
@@ -1,0 +1,165 @@
+{
+    "properties": {
+      "adlabels": {
+        "items": {
+          "properties": {
+            "created_time": {
+              "format": null
+            },
+            "updated_time": {
+              "format": null
+            }
+          }
+        }
+      },
+      "asset_feed_spec": {
+        "properties": {
+          "bodies": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "call_to_actions": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "captions": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "descriptions": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "images": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "link_urls": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "titles": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          },
+          "videos": {
+            "items": {
+              "properties": {
+                "adlabels": {
+                  "items": {
+                    "properties": {
+                      "created_time": {
+                        "format": null
+                      },
+                      "updated_time": {
+                        "format": null
+                      }
+                    }
+                  }
+                }
+              }
+            }
+          }
+        }
+      }
+    }
+  }
+  

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/ad_sets.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/ad_sets.patch.json
@@ -1,0 +1,25 @@
+{
+    "properties": {
+      "end_time": {
+        "format": null
+      },
+      "updated_time": {
+        "format": null
+      },
+      "created_time": {
+        "format": null
+      },
+      "start_time": {
+        "format": null
+      },
+      "adlabels": {
+        "items": {
+          "properties": {
+            "created_time": { "type": "string", "format": null },
+            "updated_time": { "type": "string", "format": null }
+          }
+        }
+      }
+    }
+  }
+  

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/ads.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/ads.patch.json
@@ -1,0 +1,23 @@
+{
+    "properties": {
+      "adlabels": {
+        "items": {
+          "properties": {
+            "created_time": {
+              "format": null
+            },
+            "updated_time": {
+              "format": null
+            }
+          }
+        }
+      },
+      "updated_time": {
+        "format": null
+      },
+      "created_time": {
+        "format": null
+      }
+    }
+}
+  

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/ads_insights.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/ads_insights.patch.json
@@ -1,0 +1,17 @@
+{
+    "properties": {
+      "created_time": {
+        "format": null
+      },
+      "date_start": {
+        "format": null
+      },
+      "date_stop": {
+        "format": null
+      },
+      "updated_time": {
+        "format": null
+      }
+    }
+}
+  

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/campaigns.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/campaigns.patch.json
@@ -1,0 +1,29 @@
+{
+    "properties": {
+      "adlabels": {
+        "items": {
+          "properties": {
+            "created_time": {
+              "format": null
+            },
+            "updated_time": {
+              "format": null
+            }
+          }
+        }
+      },
+      "created_time": {
+        "format": null
+      },
+      "start_time": {
+        "format": null
+      },
+      "stop_time": {
+        "format": null
+      },
+      "updated_time": {
+        "format": null
+      }
+    }
+  }
+  

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/custom_conversions.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/custom_conversions.patch.json
@@ -1,0 +1,14 @@
+{
+    "properties": {
+      "creation_time": {
+        "format": null
+      },
+      "first_fired_time": {
+        "format": null
+      },
+      "last_fired_time": {
+        "format": null
+      }
+    }
+  }
+  

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/images.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/images.patch.json
@@ -1,0 +1,10 @@
+{
+    "properties": {
+        "updated_time": {
+            "format": null
+          },
+          "created_time": {
+            "format": null
+          }
+    }
+}

--- a/airbyte-integrations/connectors/source-facebook-marketing/streams/videos.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/streams/videos.patch.json
@@ -1,3 +1,17 @@
 {
-  "type": "object"
+  "type": "object",
+  "properties": {
+    "updated_time": {
+      "format": null
+    },
+    "created_time": {
+      "format": null
+    },
+    "scheduled_publish_time": {
+      "format": null
+    },
+    "backdated_time": {
+      "format": null
+    }
+  }
 }


### PR DESCRIPTION
Facebook uses ISO8601, but JSONSchema's date-time requires RFC3339 and they are not compatible.