### PR TITLE
source-*: make credentials required for connectors that need it

### DIFF
--- a/airbyte-integrations/connectors/source-facebook-marketing/spec.patch.json
+++ b/airbyte-integrations/connectors/source-facebook-marketing/spec.patch.json
@@ -105,6 +105,7 @@
   },
   "required": [
     "account_id",
-    "start_date"
+    "start_date",
+    "credentials"
   ]
 }

--- a/airbyte-integrations/connectors/source-github/spec.patch.json
+++ b/airbyte-integrations/connectors/source-github/spec.patch.json
@@ -82,5 +82,6 @@
         }
       ]
     }
-  }
+  },
+  "required": ["start_date", "repository", "credentials"]
 }

--- a/airbyte-integrations/connectors/source-google-analytics-v4/spec.patch.json
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/spec.patch.json
@@ -78,5 +78,6 @@
     "window_in_days": {
       "description": "Number of days each read will cover, beginning at the start date. Choose a value between 1 (one day) and 364 (one year)."
     }
-  }
+  },
+  "required": ["view_id", "start_date", "credentials"]
 }

--- a/airbyte-integrations/connectors/source-linkedin-ads/spec.patch.json
+++ b/airbyte-integrations/connectors/source-linkedin-ads/spec.patch.json
@@ -58,5 +58,6 @@
         }
       ]
     }
-  }
+  },
+  "required": ["start_date", "credentials"]
 }

--- a/airbyte-integrations/connectors/source-tiktok-marketing/spec.patch.json
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/spec.patch.json
@@ -79,5 +79,6 @@
       "description":  "The granularity used for aggregating performance data in reports. See the docs: https://go.estuary.dev/umRj4Q",
       "airbyte_hidden": null
     }
-  }
+  },
+  "required": ["credentials"]
 }


### PR DESCRIPTION
Updates facebook-marketing, github, google-analytics-v4, linkedin-ads, and tiktok-marketing to include "credentials" in their list of required fields since credentials are required for these connectors to work.

I gave a brief consideration to handling for a new spec patching mechanism that would append arrays rather than overwriting them, but that felt like a bit of overkill at the moment. Such a thing would not cleanly address cases where we _don't_ want all of the fields that the base airbyte connector says are reported & need to override those anyway, such as the case with `source-facebook-marketing`, so there'd still need to be a bit of ugliness to it.