### PR TITLE
airbyte-to-flow: normalize hs_latest_source_timestamp

### DIFF
--- a/airbyte-to-flow/Cargo.lock
+++ b/airbyte-to-flow/Cargo.lock
@@ -37,9 +37,12 @@ dependencies = [
  "futures-core",
  "futures-util",
  "insta",
+ "json",
  "json-patch",
+ "lazy_static",
  "prost",
  "proto-flow",
+ "regex",
  "schemars",
  "serde",
  "serde_json",
@@ -950,9 +953,9 @@ dependencies = [
 
 [[package]]
 name = "regex"
-version = "1.6.0"
+version = "1.7.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4c4eb3267174b8c6c2f654116623910a0fef09c4753f8dd83db29c48a0df988b"
+checksum = "48aaa5748ba571fb95cd2c85c09f629215d3a6ece942baa100950af03a34f733"
 dependencies = [
  "aho-corasick",
  "memchr",

--- a/airbyte-to-flow/Cargo.toml
+++ b/airbyte-to-flow/Cargo.toml
@@ -9,6 +9,7 @@ edition = "2021"
 doc = { git = "https://github.com/estuary/flow", version = "0.0.0" }
 flow_cli_common = { git = "https://github.com/estuary/flow" }
 proto-flow = { git = "https://github.com/estuary/flow", version = "0.0.0" }
+json = { git = "https://github.com/estuary/flow", version = "0.0.0" }
 
 json-patch = "*"
 validator = { version = "*", features = ["derive"] }
@@ -33,6 +34,8 @@ thiserror = "*"
 tracing = "*"
 tokio = { version = "1", features = ["full"] }
 tokio-util = { version = "*", features = ["io"] }
+lazy_static = "1.4.0"
+regex = "1.7.1"
 
 [dev-dependencies]
 insta = "*"

--- a/airbyte-to-flow/src/interceptors/mod.rs
+++ b/airbyte-to-flow/src/interceptors/mod.rs
@@ -1,3 +1,4 @@
 pub mod airbyte_source_interceptor;
 pub mod fix_document_schema;
+pub mod normalize;
 pub mod remap;

--- a/airbyte-to-flow/src/interceptors/normalize.rs
+++ b/airbyte-to-flow/src/interceptors/normalize.rs
@@ -1,0 +1,86 @@
+use json::schema::formats::Format;
+use json::validator::ValidationResult;
+use regex::Regex;
+
+use crate::errors::Error;
+
+pub fn normalize_doc(
+    doc: &mut serde_json::Value,
+    _json_schema: &Option<serde_json::Value>,
+) -> Result<(), Error> {
+    // TODO: We should more intelligently use the schema to do normalization. I'm not going to take
+    // the time to figure that out right now, so for now we are just handling the specific case in
+    // https://github.com/estuary/airbyte/issues/123 with the field hs_latest_source_timestamp.
+    normalize_datetime_to_date(doc, doc::Pointer::from_str("/hs_latest_source_timestamp"));
+
+    Ok(())
+}
+
+lazy_static::lazy_static! {
+    // This regex is very similar to DATE_RE in the Flow repo json crate, but will match anything
+    // that looks like a date as long as it occurs at the beginning of the string.
+    static ref EXTRACT_DATE_RE: Regex =
+        Regex::new(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}").expect("Is a valid regex");
+}
+
+fn normalize_datetime_to_date(doc: &mut serde_json::Value, ptr: doc::Pointer) {
+    if let Some(val) = ptr.query(doc) {
+        val.to_owned().as_str().map(|v| {
+            match Format::Date.validate(v) {
+                ValidationResult::Valid => (), // Already a valid date
+                _ => {
+                    EXTRACT_DATE_RE.find(v).map(|mat| {
+                        ptr.create(doc)
+                            .map(|val| *val = serde_json::json!(mat.as_str()))
+                    });
+                }
+            };
+        });
+    }
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn datetime_to_date() {
+        let cases = vec![
+            (
+                serde_json::json!({
+                    "some": "thing",
+                    "hs_latest_source_timestamp": "2023-03-05T15:41:54.565000+00:00"
+                }),
+                serde_json::json!({
+                    "some": "thing",
+                    "hs_latest_source_timestamp": "2023-03-05"
+                }),
+            ),
+            (
+                serde_json::json!({
+                    "some": "thing",
+                    "hs_latest_source_timestamp": "2023-03-05"
+                }),
+                serde_json::json!({
+                    "some": "thing",
+                    "hs_latest_source_timestamp": "2023-03-05" // Already a a date
+                }),
+            ),
+            (
+                serde_json::json!({
+                    "some": "thing",
+                    "hs_latest_source_timestamp": "hello",
+                }),
+                serde_json::json!({
+                    "some": "thing",
+                    "hs_latest_source_timestamp": "hello", // A string, but can't be normalized to a date
+                }),
+            ),
+        ];
+
+        for mut case in cases {
+            normalize_doc(&mut case.0, &None).unwrap();
+            assert_eq!(case.0, case.1);
+        }
+    }
+}

--- a/airbyte-to-flow/src/libs/airbyte_catalog.rs
+++ b/airbyte-to-flow/src/libs/airbyte_catalog.rs
@@ -138,7 +138,7 @@ pub struct ConnectionStatus {
 #[serde(rename_all = "snake_case")]
 pub struct Record {
     pub stream: String,
-    pub data: Box<RawValue>,
+    pub data: serde_json::Value,
     pub emitted_at: i64,
     pub namespace: Option<String>,
 }


### PR DESCRIPTION
This is a fairly quick-and-dirty fix to hubspot captures having the field `hs_latest_source_timestamp` coming through looking like a `date-time` instead of a `date`, which breaks existing captures using the `format: date` in their schema for this field.

It adds processing to normalize this specific field, attempting to extract the equivalent `date` value from the `date-time`-ish string if it is present.

Future work should be more intelligent about this and use the collection schema, but for now I have it hard coded to handle the field `hs_latest_source_timestamp` to unblock existing captures.

Note that the first commit is entirely changes from `rustfmt` on `airbyte-source-interceptor.rs`. The meaningful modifications occur in the second commit, df455ad.