### PR TITLE
airbyte-to-flow: restart idle connectors

### DIFF
--- a/airbyte-to-flow/src/errors.rs
+++ b/airbyte-to-flow/src/errors.rs
@@ -86,6 +86,9 @@ pub enum Error {
 
     #[error("go.estuary.dev/uzQS5j: Unknown operation: {0}")]
     UnknownOperation(String),
+
+    #[error("go.estuary.dev/x2W2J5: Connector has been idle")]
+    IdleConnector,
 }
 
 pub fn raise_err<T>(message: &str) -> Result<T, std::io::Error> {


### PR DESCRIPTION
Some airbyte connectors hang, it's a known issue: https://github.com/airbytehq/airbyte/issues/14499
Airbyte's solution to this seems to be restarting idle connectors. Here I'm implementing a similar logic that we restart idle connectors after 10 minutes of inactivity.