### PR TITLE
fix notion connector start date field

### DIFF
--- a/airbyte-integrations/connectors/source-notion/spec.patch.json
+++ b/airbyte-integrations/connectors/source-notion/spec.patch.json
@@ -2,7 +2,7 @@
   "required": ["start_date", "credentials"],
   "properties": {
     "start_date": {
-      "format": "date-time"
+      "default": "2023-04-17T00:00:00.000Z"
     },
     "credentials": {
       "title": "Authenticate using",


### PR DESCRIPTION
Remove date picker and add default value for start date to help user understand the date formatting requirement.