### PR TITLE
airbyte-to-flow: add normalization to remove nonstandard jsonschema

### DIFF
--- a/.github/workflows/connectors.yml
+++ b/.github/workflows/connectors.yml
@@ -175,12 +175,18 @@ jobs:
       - name: Build ${{ matrix.connector.name }}
         id: build
         run: |
+          AIRBYTE_TO_FLOW_TAG=dev
+          if [ "$GITHUB_EVENT_NAME" == "pull_request" ]; then
+            AIRBYTE_TO_FLOW_TAG=${{ steps.prep.outputs.tag }}
+          fi
+
           if [ -f "airbyte-integrations/connectors/${{ matrix.connector.name }}/requirements.txt" ]; then
             ./gradlew :airbyte-integrations:connectors:${{ matrix.connector.name }}:build
             docker tag docker.io/airbyte/${{ matrix.connector.name }}:dev ghcr.io/estuary/${{ matrix.connector.name }}:${{ steps.prep.outputs.tag }}
           else
             docker build "airbyte-integrations/connectors/${{ matrix.connector.name }}" \
                    -f "airbyte-integrations/connectors/${{ matrix.connector.name }}/Dockerfile" \
+                   --build-arg AIRBYTE_TO_FLOW_TAG=$AIRBYTE_TO_FLOW_TAG \
                    -t ghcr.io/estuary/${{ matrix.connector.name }}:${{ steps.prep.outputs.tag }}
           fi
           

--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -1,3 +1,6 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM python:3.9-slim
 
 # Bash is installed for more convenient debugging.
@@ -12,7 +15,7 @@ RUN pip install .
 COPY *.patch.json ./
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 LABEL io.airbyte.version=v1

--- a/airbyte-integrations/connectors/source-amplitude/Dockerfile
+++ b/airbyte-integrations/connectors/source-amplitude/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-amplitude:0.2.0
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-bing-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-bing-ads/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-bing-ads:0.1.19
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-exchange-rates/Dockerfile
+++ b/airbyte-integrations/connectors/source-exchange-rates/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-exchange-rates:1.2.8
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./airbyte-to-flow
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY spec.patch.json ./

--- a/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-facebook-marketing/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-facebook-marketing:0.3.3
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY spec.patch.json ./

--- a/airbyte-integrations/connectors/source-github/Dockerfile
+++ b/airbyte-integrations/connectors/source-github/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-github:0.4.7
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY *.json ./

--- a/airbyte-integrations/connectors/source-google-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-ads/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-google-ads:0.2.13
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-google-analytics-data-api:0.1.3
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY spec.patch.json ./

--- a/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-google-analytics-v4:0.1.34
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-google-search-console/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-search-console/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-google-search-console:0.1.22
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -1,3 +1,6 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM python:3.9.11-alpine3.15 as base
 
 # build and load all requirements
@@ -35,7 +38,7 @@ COPY spec.patch.json ./
 COPY oauth2.patch.json ./
 
 ENV AIRBYTE_ENTRYPOINT "python /airbyte/integration_code/main.py"
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 LABEL io.airbyte.version=v1

--- a/airbyte-integrations/connectors/source-hubspot/Dockerfile
+++ b/airbyte-integrations/connectors/source-hubspot/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-hubspot:0.6.0
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-intercom/Dockerfile
+++ b/airbyte-integrations/connectors/source-intercom/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-intercom:0.2.0
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-linkedin-ads/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-linkedin-ads:0.1.15
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-mailchimp/Dockerfile
+++ b/airbyte-integrations/connectors/source-mailchimp/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-mailchimp:0.3.5
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-notion/Dockerfile
+++ b/airbyte-integrations/connectors/source-notion/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-notion:1.0.4
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-integrations/connectors/source-salesforce/Dockerfile
+++ b/airbyte-integrations/connectors/source-salesforce/Dockerfile
@@ -1,3 +1,6 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM python:3.9-slim
 
 # Bash is installed for more convenient debugging.
@@ -14,7 +17,7 @@ COPY *.map.json ./
 COPY selected_streams.json ./
 RUN pip install .
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 LABEL io.airbyte.version=v1

--- a/airbyte-integrations/connectors/source-slack/Dockerfile
+++ b/airbyte-integrations/connectors/source-slack/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-slack:0.1.25
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY spec.patch.json ./

--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-stripe:3.3.0
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY *.json ./

--- a/airbyte-integrations/connectors/source-surveymonkey/Dockerfile
+++ b/airbyte-integrations/connectors/source-surveymonkey/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-surveymonkey:0.1.16
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY *.json ./

--- a/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
+++ b/airbyte-integrations/connectors/source-tiktok-marketing/Dockerfile
@@ -1,6 +1,9 @@
+ARG AIRBYTE_TO_FLOW_TAG="dev"
+FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
+
 FROM airbyte/source-tiktok-marketing:3.0.1
 
-COPY --from=ghcr.io/estuary/airbyte-to-flow:dev /airbyte-to-flow ./
+COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]
 
 COPY documentation_url.patch.json ./

--- a/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
+++ b/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
@@ -31,7 +31,7 @@ use tempfile::{Builder, TempDir};
 
 use json_patch::merge;
 
-use super::fix_document_schema::fix_document_schema_keys;
+use super::fix_document_schema::{fix_document_schema_keys, fix_nonstandard_jsonschema_attributes};
 use super::normalize::{normalize_doc, NormalizationEntry};
 use super::remap::remap;
 
@@ -118,6 +118,8 @@ impl AirbyteSourceInterceptor {
                     .map(|s| s.to_string()),
                 None => spec.documentation_url,
             };
+
+            fix_nonstandard_jsonschema_attributes(&mut endpoint_spec);
 
             let v = serde_json::to_vec(&Response { spec: Some(response::Spec {
                 protocol: PROTOCOL_VERSION,
@@ -240,6 +242,8 @@ impl AirbyteSourceInterceptor {
                 if let Some(p) = doc_schema_patch {
                     merge(&mut doc_schema, &p);
                 }
+
+                fix_nonstandard_jsonschema_attributes(&mut doc_schema);
 
                 resp.bindings.push(response::discovered::Binding {
                     recommended_name,


### PR DESCRIPTION
- Remove airbyte's recently introduced nonstandard JSONSchema attributes such as `group`, `airbyte_hidden` and `airbyte_type`
- Updated CI so that when working on a pull-request, connectors built in the pull-request will use the `airbyte-to-flow` version from the same branch to help with testing.