### PR TITLE
remove enums

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/streams/attached_item.patch.json
+++ b/airbyte-integrations/connectors/source-chargebee/streams/attached_item.patch.json
@@ -1,0 +1,19 @@
+{
+    "custom_fields": null,
+    "properties": {
+        "custom_fields": {
+            "type": ["null", "array"],
+            "items": {
+                "type": ["null", "object"],
+                "properties": {
+                    "name": {
+                        "type": ["null", "string"]
+                    },
+                    "value": {
+                        "type": ["null", "string"]
+                    }
+                }
+            }
+        }
+    }
+}

--- a/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
+++ b/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
@@ -31,7 +31,7 @@ use tempfile::{Builder, TempDir};
 
 use json_patch::merge;
 
-use super::fix_document_schema::{fix_document_schema_keys, fix_nonstandard_jsonschema_attributes};
+use super::fix_document_schema::{fix_document_schema_keys, fix_nonstandard_jsonschema_attributes, remove_enums};
 use super::normalize::{normalize_doc, NormalizationEntry};
 use super::remap::remap;
 
@@ -249,6 +249,7 @@ impl AirbyteSourceInterceptor {
                 }
 
                 fix_nonstandard_jsonschema_attributes(&mut doc_schema);
+                remove_enums(&mut doc_schema);
 
                 resp.bindings.push(response::discovered::Binding {
                     recommended_name,

--- a/airbyte-to-flow/src/interceptors/fix_document_schema.rs
+++ b/airbyte-to-flow/src/interceptors/fix_document_schema.rs
@@ -133,6 +133,9 @@ pub fn fix_nonstandard_jsonschema_attributes(schema: &mut serde_json::Value) {
 
         // a mapping from a jsonschema type to an internal airbyte type
         map.remove("airbyte_type");
+
+        // another attribute that is sometimes used in airbyte schemas
+        map.remove("name");
     })
 }
 


### PR DESCRIPTION
- move logic for traversing a jsonschema document to `traverse_jsonschema` and use it to write a new normalization: `remove_enums`