### PR TITLE
payment_method_types is an array of strings, that `card` is just wrong

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/streams/checkout_sessions.patch.json
+++ b/airbyte-integrations/connectors/source-stripe/streams/checkout_sessions.patch.json
@@ -6,7 +6,8 @@
           "type": [
             "string",
             "null"
-          ]
+          ],
+          "card": null
         }
       }
     } 


### PR DESCRIPTION
https://stripe.com/docs/api/checkout/sessions/object