### PR TITLE
source-stripe: schema patches

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/streams/customers.patch.json
+++ b/airbyte-integrations/connectors/source-stripe/streams/customers.patch.json
@@ -1,0 +1,26 @@
+{
+  "properties": {
+    "tax_info": {
+      "properties": {
+        "tax_id": {
+          "type": ["string", "null"]
+        },
+        "type": {
+          "type": ["string", "null"]
+        }
+      },
+      "type": ["object", "null"]
+    },
+    "tax_info_verification": {
+      "properties": {
+        "status": {
+          "type": ["string", "null"]
+        },
+        "verified_name": {
+          "type": ["string", "null"]
+        }
+      },
+      "type": ["object", "null"]
+    }
+  }
+}

--- a/airbyte-integrations/connectors/source-stripe/streams/subscription_schedule.patch.json
+++ b/airbyte-integrations/connectors/source-stripe/streams/subscription_schedule.patch.json
@@ -1,0 +1,7 @@
+{
+  "properties": {
+    "cancelled_at": {
+      "type": ["integer", "null"]
+    }
+  }
+}


### PR DESCRIPTION
A couple of schema patches for `source-stripe` based on data we have seen from a running capture.