### PR TITLE
atf: unix to datetime normalization, array items normalization

### DIFF
--- a/airbyte-integrations/connectors/source-stripe/Dockerfile
+++ b/airbyte-integrations/connectors/source-stripe/Dockerfile
@@ -9,7 +9,7 @@ ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint
 COPY *.json ./
 COPY streams/* ./streams/
 
-LABEL io.airbyte.version=v2
+LABEL io.airbyte.version=v3
 LABEL io.airbyte.name=airbyte/source-stripe
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture

--- a/airbyte-integrations/connectors/source-stripe/streams/subscription_schedule.patch.json
+++ b/airbyte-integrations/connectors/source-stripe/streams/subscription_schedule.patch.json
@@ -1,13 +1,16 @@
 {
   "properties": {
     "cancelled_at": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "completed_at": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "released_at": {
-      "type": ["integer", "null"]
+      "type": ["string", "null"],
+      "format": "date-time"
     },
     "current_phase": {
       "type": ["object", "null"]
@@ -43,8 +46,17 @@
               }
             }
           },
+          "end_date": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
+          "start_date": {
+            "type": ["string", "null"],
+            "format": "date-time"
+          },
           "trial_end": {
-            "type": ["integer", "null"]
+            "type": ["string", "null"],
+            "format": "date-time"
           }
         }
       }

--- a/airbyte-to-flow/src/interceptors/fix_document_schema.rs
+++ b/airbyte-to-flow/src/interceptors/fix_document_schema.rs
@@ -147,8 +147,7 @@ where
                 }
                 _ => (),
             });
-            map.get_mut("items")
-                .map(|item| traverse_jsonschema(item, f, format!("{ptr}/-")));
+            map.get_mut("items").map(|item| traverse_jsonschema(item, f, format!("{ptr}/*")));
         }
         _ => (),
     }


### PR DESCRIPTION
- Update `normalize_to_rfc3339` so it also checks for integer values and considers them as Unix seconds timestamps (we can later add support for other Unix timestamps). This happens if the field is marked as `format: "date-time"`, but has a numeric value.
- Update `automatic_normalizations` function so that it can handle normalization of array items as well. The implementation here is pretty gross. Ideally this should be refactored into `traverse_jsonschema`, I attempted to do that, but there was some challenge there with the fact that it becomes hard to reason about ownership of `doc` if both `traverse_jsonschema` itself and the closure passed to want to hold a reference to `doc`. So for now I've settled on this implementation.