### PR TITLE
atf: plumb through exit code transparently (no error message)

### DIFF
--- a/airbyte-to-flow/src/errors.rs
+++ b/airbyte-to-flow/src/errors.rs
@@ -11,6 +11,9 @@ pub enum Error {
     #[error("Failed to execute command: {0}")]
     CommandExecutionError(String),
 
+    #[error("Connector exit with code {0}")]
+    ExitCode(i32),
+
     #[error("Unable to create an IO pipe to the connector")]
     MissingIOPipe,
 

--- a/airbyte-to-flow/src/libs/command.rs
+++ b/airbyte-to-flow/src/libs/command.rs
@@ -15,10 +15,7 @@ pub fn check_exit_status(message: &str, result: std::io::Result<ExitStatus>) -> 
                 Ok(())
             } else {
                 match status.code() {
-                    Some(code) => Err(Error::CommandExecutionError(format!(
-                        "{} failed with code {}.",
-                        message, code
-                    ))),
+                    Some(code) => Err(Error::ExitCode(code)),
                     None => Err(Error::CommandExecutionError(format!(
                         "{} process terminated by signal",
                         message

--- a/airbyte-to-flow/src/main.rs
+++ b/airbyte-to-flow/src/main.rs
@@ -1,5 +1,6 @@
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
+use errors::Error;
 use flow_cli_common::{init_logging, LogArgs, LogLevel};
 
 pub mod apis;
@@ -61,6 +62,9 @@ fn main() -> anyhow::Result<()> {
     runtime.shutdown_background();
 
     match result {
+        Err(Error::ExitCode(code)) => {
+            std::process::exit(code);
+        }
         Err(err) => {
             Err(err.into())
         }


### PR DESCRIPTION
See discussion here: https://github.com/estuary/airbyte/issues/193