### PR TITLE
source-surveymonkey: fix oauth

### DIFF
--- a/airbyte-integrations/connectors/source-surveymonkey/spec.map.json
+++ b/airbyte-integrations/connectors/source-surveymonkey/spec.map.json
@@ -1,3 +1,0 @@
-{
-  "/access_token": "/credentials/access_token"
-}


### PR DESCRIPTION
This patch isn't needed anymore, since the airbyte connector actually wants the access token to be at `/credentials/access_token`.

Tested this with `flowctl raw discover` & `flowctl raw capture`.