### PR TITLE
atf: schema normalizations, date to datetime for salesforce

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/schema_normalizations.json
+++ b/airbyte-integrations/connectors/source-salesforce/schema_normalizations.json
@@ -1,0 +1,1 @@
+["date_to_datetime"]


### PR DESCRIPTION
Salesforce connector outputs `format: "date"` for some fields, but all fields in Salesforce are represented as `date-time`, and we frequently run into this issue.

This PR allows for us to specify some schema normalizations to be enabled for specific connectors through a new config file. I'm enabling this normalization for salesforce which replaces all `format: "date"` with `format: "date-time"`