### PR TITLE
airbyte-to-flow: support airbyte's new TRACE messages

### DIFF
--- a/airbyte-to-flow/src/libs/airbyte_catalog.rs
+++ b/airbyte-to-flow/src/libs/airbyte_catalog.rs
@@ -169,6 +169,21 @@ impl Log {
     }
 }
 
+#[derive(Debug, Serialize, Deserialize, Clone, PartialEq)]
+#[serde(rename_all = "camelCase")]
+pub struct Trace {
+    #[serde(rename="type")]
+    pub type_: String,
+
+    #[serde(flatten)]
+    extra: HashMap<String, serde_json::Value>,
+}
+impl Trace {
+    pub fn trace(&self) {
+        tracing::debug!("{}: {:?}", self.type_, self.extra);
+    }
+}
+
 #[derive(Debug, Serialize, Deserialize, Clone)]
 #[serde(rename_all = "snake_case")]
 pub struct State {
@@ -213,6 +228,7 @@ pub enum MessageType {
     Record,
     State,
     Log,
+    Trace,
     Spec,
     ConnectionStatus,
     Catalog,
@@ -225,6 +241,7 @@ pub struct Message {
     pub message_type: MessageType,
 
     pub log: Option<Log>,
+    pub trace: Option<Trace>,
     pub state: Option<State>,
     pub record: Option<Record>,
     pub connection_status: Option<ConnectionStatus>,

--- a/airbyte-to-flow/src/libs/stream.rs
+++ b/airbyte-to-flow/src/libs/stream.rs
@@ -50,7 +50,8 @@ pub fn stream_airbyte_responses(
                     log: Some(Log {
                         level: LogLevel::Debug,
                         message: format!("Encountered error while trying to parse ATF Message: {:?} in line {:?}", e, line)
-                    })
+                    }),
+                    trace: None,
                 }
             }
         };
@@ -62,10 +63,13 @@ pub fn stream_airbyte_responses(
         Ok(Some(message))
     })
     .try_filter_map(|message| async {
-        // For AirbyteLogMessages, log them and then filter them out
+        // For logs and traces, log them and then filter them out
         // so that we don't have to handle them elsewhere
         if let Some(log) = message.log {
             log.log();
+            Ok(None)
+        } else if let Some(trace) = message.trace {
+            trace.trace();
             Ok(None)
         } else {
             Ok(Some(message))
@@ -164,6 +168,7 @@ mod test {
             record: None,
             spec: None,
             catalog: None,
+            trace: None,
             connection_status: Some(ConnectionStatus {
                 status: Status::Succeeded,
                 message: Some("test".to_string()),
@@ -193,6 +198,7 @@ mod test {
             record: None,
             spec: None,
             catalog: None,
+            trace: None,
             connection_status: Some(ConnectionStatus {
                 status: Status::Succeeded,
                 message: Some("test".to_string()),
@@ -222,6 +228,7 @@ mod test {
             record: None,
             spec: None,
             catalog: None,
+            trace: None,
             connection_status: Some(ConnectionStatus {
                 status: Status::Succeeded,
                 message: Some("test".to_string()),


### PR DESCRIPTION
Airbyte has introduced a new type of message `TRACE`, adding preliminary support for it here.