### PR TITLE
Phil/rm pattern descriptor

### DIFF
--- a/airbyte-integrations/connectors/source-postgres-heroku/Dockerfile
+++ b/airbyte-integrations/connectors/source-postgres-heroku/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-postgres:2.0.33
+FROM airbyte/source-postgres:3.0.2
 
 COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/airbyte-to-flow", "--connector-entrypoint", "/airbyte/base.sh"]

--- a/airbyte-integrations/connectors/source-postgres-heroku/spec.patch.json
+++ b/airbyte-integrations/connectors/source-postgres-heroku/spec.patch.json
@@ -6,12 +6,12 @@
       "properties": {
         "method": {
           "type": "string",
-          "default": "Standard",
-          "const": "Standard"
+          "default": "Xmin",
+          "const": "Xmin"
         }
       },
       "default": {
-        "method": "Standard"
+        "method": "Xmin"
       }
     },
     "jdbc_url_params": {

--- a/airbyte-integrations/connectors/source-postgres-heroku/spec.patch.json
+++ b/airbyte-integrations/connectors/source-postgres-heroku/spec.patch.json
@@ -94,7 +94,6 @@
             },
             "client_certificate": {
               "airbyte_secret": true,
-              "always_show": true,
               "description": "Client certificate",
               "multiline": true,
               "order": 2,
@@ -103,7 +102,6 @@
             },
             "client_key": {
               "airbyte_secret": true,
-              "always_show": true,
               "description": "Client key",
               "multiline": true,
               "order": 3,
@@ -143,7 +141,6 @@
             },
             "client_certificate": {
               "airbyte_secret": true,
-              "always_show": true,
               "description": "Client certificate",
               "multiline": true,
               "order": 2,
@@ -152,7 +149,6 @@
             },
             "client_key": {
               "airbyte_secret": true,
-              "always_show": true,
               "description": "Client key",
               "multiline": true,
               "order": 3,


### PR DESCRIPTION
We saw a number of problems with `source-postgres-heroku` (Airbyte's `source-postgres`).

First was an issue with the endpoint spec schema, which caused our encryption endpoint to fail when creating captures via the UI. This was solved by removing unknown keywords from the spec schema.

Second is that the connector failed to ingest data from a table that had an integer primary key. The Discover RPC returns a schema with `type: number` for that field, which Flow doesn't allow for primary keys. Changing the type to `integer` in the collection schema allows the build to work, but causes an exception in the connector. The second commit here changes the replication method to always use "Xmin", which we thought might allow us to use `type: integer`, but it seems to still cause an exception when you use `type: integer` in the collection schema. This is tracked upstream in airbytehq/airbyte#28529

So it seems like this connector may just not work until the error with integer fields is fixed upstream. In the meantime, we can either merge this (it's _already_ broken 🤷) or keep it around as a draft / reminder to follow up.