### PR TITLE
source-salesforce: use older airbyte image

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/Dockerfile
+++ b/airbyte-integrations/connectors/source-salesforce/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-salesforce:2.0.12
+FROM airbyte/source-salesforce:2.0.7
 
 COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]


### PR DESCRIPTION
Use airbyte salesforce 2.0.7, since anything after 2.0.9 has been shown to miss data, and there is no published image for 2.0.8.