### PR TITLE
atf: support wildcard schema patches, apply one for salesforce reduction

### DIFF
--- a/airbyte-integrations/connectors/source-salesforce/streams/*.patch.json
+++ b/airbyte-integrations/connectors/source-salesforce/streams/*.patch.json
@@ -1,0 +1,5 @@
+{
+  "reduce": {
+    "strategy": "merge"
+  }
+}

--- a/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
+++ b/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
@@ -269,6 +269,12 @@ impl AirbyteSourceInterceptor {
                     "{}/{}{}",
                     STREAM_PATCH_DIR_NAME, recommended_name, STREAM_PATCH_SUFFIX
                 ))
+                .or_else(|_| {
+                    std::fs::read_to_string(format!(
+                        "{}/*{}",
+                        STREAM_PATCH_DIR_NAME, STREAM_PATCH_SUFFIX
+                    ))
+                })
                 .ok()
                 .map(|p| sj::from_str::<sj::Value>(&p))
                 .transpose()?;


### PR DESCRIPTION
- add support for reading wildcard patch files `*.patch.json`
- add a wildcard patch file for salesforce to add reduction strategy to the connector (this helps when using it beside the real-time connector)