### PR TITLE
Removed unnecessary keys from Amazon Ads Attribution Report

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/streams/attribution_report_performance_campaign.pk.json
+++ b/airbyte-integrations/connectors/source-amazon-ads/streams/attribution_report_performance_campaign.pk.json
@@ -1,1 +1,1 @@
-["date", "campaignId", "adGroupId", "publisher", "advertiserName"]
+["date", "campaignId", "advertiserName"]


### PR DESCRIPTION
removed "adGroupId" and "publisher" attribution_report_performance_campaign.pk.json