### PR TITLE
airbyte-to-flow: remove format: base64 from schema

### DIFF
--- a/airbyte-to-flow/src/interceptors/fix_document_schema.rs
+++ b/airbyte-to-flow/src/interceptors/fix_document_schema.rs
@@ -187,6 +187,9 @@ pub fn fix_nonstandard_jsonschema_attributes(schema: &mut serde_json::Value) {
                 if f == "int32" || f == "int64" {
                     // Insert updates values
                     map.insert("format".to_string(), json!("integer"));
+                } else if f == "base64" {
+                    // a non-standard format output by salesforce connector
+                    map.remove("format");
                 }
             }
         },
@@ -540,7 +543,8 @@ mod test {
                         },
                         "id": {
                             "type": ["string", "null"],
-                            "group": "test"
+                            "group": "test",
+                            "format": "base64"
                         }
                     }
                 }


### PR DESCRIPTION
Salesforce connector sometimes outputs `format: base64` which is not a standard JSONSchema `format` value and we fail on this: https://github.com/airbytehq/airbyte/blob/f54bd550aae9b4bf19220b50af47da0adc3b4ff1/airbyte-integrations/connectors/source-salesforce/source_salesforce/api.py#L413C71-L413C71

This pull-request removes this stanza if it exists.