### PR TITLE
atf: cleanup error outputs

### DIFF
--- a/.github/workflows/connectors.yml
+++ b/.github/workflows/connectors.yml
@@ -93,7 +93,7 @@ jobs:
           username: ${{ github.actor }}
           password: ${{ secrets.GITHUB_TOKEN }}
 
-      - name: Build and push
+      - name: Build and push (dev and commit tag)
         uses: docker/build-push-action@v3
         if: needs.paths-filter.outputs.atf_modified == 'true' && github.ref == 'refs/heads/master'
         with:
@@ -102,7 +102,7 @@ jobs:
           push: true
           tags: ghcr.io/estuary/airbyte-to-flow:dev,ghcr.io/estuary/airbyte-to-flow:${{ steps.prep.outputs.tag }}
 
-      - name: Build and push
+      - name: Build and push (commit tag)
         uses: docker/build-push-action@v3
         if: needs.paths-filter.outputs.atf_modified == 'true' && github.ref != 'refs/heads/master'
         with:
@@ -211,6 +211,8 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" && '${{ needs.paths-filter.outputs.atf_modified }}' == 'true' ]]; then
             AIRBYTE_TO_FLOW_TAG=${{ steps.prep.outputs.tag }}
           fi
+          echo "$GITHUB_EVENT_NAME"
+          echo $AIRBYTE_TO_FLOW_TAG
 
           if [ -f "airbyte-integrations/connectors/${{ matrix.connector.name }}/requirements.txt" ]; then
             ./gradlew :airbyte-integrations:connectors:${{ matrix.connector.name }}:build

--- a/.github/workflows/connectors.yml
+++ b/.github/workflows/connectors.yml
@@ -211,13 +211,14 @@ jobs:
           if [[ "$GITHUB_EVENT_NAME" == "pull_request" && '${{ needs.paths-filter.outputs.atf_modified }}' == 'true' ]]; then
             AIRBYTE_TO_FLOW_TAG=${{ steps.prep.outputs.tag }}
           fi
-          echo "$GITHUB_EVENT_NAME"
-          echo $AIRBYTE_TO_FLOW_TAG
 
           if [ -f "airbyte-integrations/connectors/${{ matrix.connector.name }}/requirements.txt" ]; then
+            export AIRBYTE_TO_FLOW_TAG
+
             ./gradlew :airbyte-integrations:connectors:${{ matrix.connector.name }}:build
             docker tag docker.io/airbyte/${{ matrix.connector.name }}:dev ghcr.io/estuary/${{ matrix.connector.name }}:${{ steps.prep.outputs.tag }}
           else
+
             docker build "airbyte-integrations/connectors/${{ matrix.connector.name }}" \
                    -f "airbyte-integrations/connectors/${{ matrix.connector.name }}/Dockerfile" \
                    --build-arg AIRBYTE_TO_FLOW_TAG=$AIRBYTE_TO_FLOW_TAG \

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -1,4 +1,4 @@
-ARG AIRBYTE_TO_FLOW_TAG="9218477"
+ARG AIRBYTE_TO_FLOW_TAG="1ae3654"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
 FROM python:3.9.11-alpine3.15 as base

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -1,4 +1,4 @@
-ARG AIRBYTE_TO_FLOW_TAG="dev"
+ARG AIRBYTE_TO_FLOW_TAG="9218477"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
 FROM python:3.9.11-alpine3.15 as base

--- a/airbyte-integrations/connectors/source-google-sheets/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-sheets/Dockerfile
@@ -1,4 +1,4 @@
-ARG AIRBYTE_TO_FLOW_TAG="1ae3654"
+ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
 FROM python:3.9.11-alpine3.15 as base

--- a/airbyte-to-flow/src/connector_runner.rs
+++ b/airbyte-to-flow/src/connector_runner.rs
@@ -267,10 +267,10 @@ async fn streaming_all(
                 },
                 // This error usually happens because there is an underlying error
                 // in the connector. We don't want this error to obscure the real error
-                // so we just log it as a warning and let the last output error
+                // so we just log it as a debug and let the last output error
                 // to take precedence
                 Err(e @ Error::EmptyStream) => {
-                    tracing::warn!("{}", e.to_string());
+                    tracing::debug!("{}", e.to_string());
                 }
                 Err(e) => Err::<(), std::io::Error>(e.into())?,
             }

--- a/airbyte-to-flow/src/connector_runner.rs
+++ b/airbyte-to-flow/src/connector_runner.rs
@@ -148,7 +148,7 @@ pub async fn run_airbyte_source_connector(
     let exit_status_task = async move {
         let c = Arc::clone(child_arc);
 
-        let exit_status_result = check_exit_status("atf:", c.lock().await.wait().await);
+        let exit_status_result = check_exit_status(c.lock().await.wait().await);
 
         // There are some Airbyte connectors that write records, and exit successfully, without ever writing
         // a state (checkpoint). In those cases, we want to provide a default empty checkpoint. It's important that

--- a/airbyte-to-flow/src/connector_runner.rs
+++ b/airbyte-to-flow/src/connector_runner.rs
@@ -18,7 +18,7 @@ use proto_flow::flow::ConnectorState;
 
 use crate::{
     apis::InterceptorStream,
-    errors::{interceptor_stream_to_io_stream, io_stream_to_interceptor_stream, Error},
+    errors::{io_stream_to_interceptor_stream, Error},
     interceptors::airbyte_source_interceptor::{AirbyteSourceInterceptor, Operation},
     libs::command::{check_exit_status, invoke_connector_delayed},
 };
@@ -249,9 +249,9 @@ async fn streaming_all(
     response_finished_sender: oneshot::Sender<bool>,
 ) -> Result<(), Error> {
     let mut request_stream_reader =
-        StreamReader::new(interceptor_stream_to_io_stream(request_stream));
+        StreamReader::new(request_stream);
     let mut response_stream_reader =
-        StreamReader::new(interceptor_stream_to_io_stream(response_stream));
+        StreamReader::new(response_stream);
 
     let request_stream_copy = async move {
         copy(&mut request_stream_reader, &mut request_stream_writer).await?;

--- a/airbyte-to-flow/src/connector_runner.rs
+++ b/airbyte-to-flow/src/connector_runner.rs
@@ -265,6 +265,10 @@ async fn streaming_all(
                 Ok(bytes) => {
                     writer.write(&bytes).await?;
                 },
+                // This error usually happens because there is an underlying error
+                // in the connector. We don't want this error to obscure the real error
+                // so we just log it as a warning and let the last output error
+                // to take precedence
                 Err(e @ Error::EmptyStream) => {
                     tracing::warn!("{}", e.to_string());
                 }

--- a/airbyte-to-flow/src/errors.rs
+++ b/airbyte-to-flow/src/errors.rs
@@ -1,7 +1,7 @@
 use std::num::ParseIntError;
 
 use bytes::Bytes;
-use futures::{Stream, TryStream, TryStreamExt};
+use futures::{Stream, TryStreamExt};
 use validator::ValidationErrors;
 
 use crate::apis::InterceptorStream;
@@ -74,10 +74,10 @@ pub fn create_custom_error(message: &str) -> std::io::Error {
     std::io::Error::new(std::io::ErrorKind::Other, message)
 }
 
-pub fn interceptor_stream_to_io_stream(
-    stream: InterceptorStream,
-) -> impl TryStream<Item = std::io::Result<Bytes>, Ok = Bytes, Error = std::io::Error> {
-    stream.map_err(|e| create_custom_error(&e.to_string()))
+impl Into<std::io::Error> for Error {
+    fn into(self) -> std::io::Error {
+        create_custom_error(&self.to_string())
+    }
 }
 
 pub fn io_stream_to_interceptor_stream(

--- a/airbyte-to-flow/src/libs/command.rs
+++ b/airbyte-to-flow/src/libs/command.rs
@@ -7,19 +7,16 @@ pub const READY: &[u8] = "READY\n".as_bytes();
 
 // Check the connector execution exit status.
 // TODO: replace this function after `exit_status_error` is stable. https://github.com/rust-lang/rust/issues/84908
-pub fn check_exit_status(message: &str, result: std::io::Result<ExitStatus>) -> Result<(), Error> {
+pub fn check_exit_status(result: std::io::Result<ExitStatus>) -> Result<(), Error> {
     match result {
         Ok(status) => {
             if status.success() {
-                tracing::info!("{} exited without error", message);
+                tracing::info!("atf: exited without error");
                 Ok(())
             } else {
                 match status.code() {
                     Some(code) => Err(Error::ExitCode(code)),
-                    None => Err(Error::CommandExecutionError(format!(
-                        "{} process terminated by signal",
-                        message
-                    ))),
+                    None => Err(Error::CommandExecutionError("atf: process terminated by signal".to_string())),
                 }
             }
         }

--- a/airbyte-to-flow/src/libs/command.rs
+++ b/airbyte-to-flow/src/libs/command.rs
@@ -11,7 +11,7 @@ pub fn check_exit_status(result: std::io::Result<ExitStatus>) -> Result<(), Erro
     match result {
         Ok(status) => {
             if status.success() {
-                tracing::info!("atf: exited without error");
+                tracing::debug!("atf: exited without error");
                 Ok(())
             } else {
                 match status.code() {

--- a/airbyte-to-flow/src/libs/stream.rs
+++ b/airbyte-to-flow/src/libs/stream.rs
@@ -1,7 +1,7 @@
 use crate::libs::airbyte_catalog::Message;
 use crate::{apis::InterceptorStream, errors::create_custom_error};
 
-use crate::errors::{interceptor_stream_to_io_stream, io_stream_to_interceptor_stream, Error};
+use crate::errors::{io_stream_to_interceptor_stream, Error};
 use bytelines::AsyncByteLines;
 use bytes::Bytes;
 use futures::{StreamExt, TryStream, TryStreamExt};
@@ -17,9 +17,9 @@ pub fn stream_lines(
     in_stream: InterceptorStream,
 ) -> impl TryStream<Item = Result<Bytes, Error>, Error = Error, Ok = bytes::Bytes> {
     io_stream_to_interceptor_stream(
-        AsyncByteLines::new(StreamReader::new(interceptor_stream_to_io_stream(
+        AsyncByteLines::new(StreamReader::new(
             in_stream,
-        )))
+        ))
         .into_stream()
         .map_ok(Bytes::from),
     )

--- a/airbyte-to-flow/src/main.rs
+++ b/airbyte-to-flow/src/main.rs
@@ -68,7 +68,7 @@ fn main() -> anyhow::Result<()> {
         },
         Err(err) => Err(err.into()),
         Ok(()) => {
-            tracing::info!(message = "atf exiting");
+            tracing::debug!(message = "atf exiting");
             Ok(())
         }
     }

--- a/airbyte-to-flow/src/main.rs
+++ b/airbyte-to-flow/src/main.rs
@@ -62,16 +62,9 @@ fn main() -> anyhow::Result<()> {
     // (Note that tokio::io maps AsyncRead of file descriptors to blocking tasks under the hood).
     runtime.shutdown_background();
 
-    tracing::warn!(raw_response = ?result);
     match result {
         Err(Error::ExitCode(code)) => {
             std::process::exit(code);
-        },
-        Err(e @ Error::EmptyStream) | Err(e @ Error::CheckpointPending) => {
-            // In some cases, we want to let the last error of the connector
-            // be picked up by connector-init as the actual error
-            tracing::warn!(message = e.to_string());
-            std::process::exit(1);
         },
         Err(err) => Err(err.into()),
         Ok(()) => {

--- a/airbyte-to-flow/src/main.rs
+++ b/airbyte-to-flow/src/main.rs
@@ -1,3 +1,4 @@
+use std::error::Error as StdError;
 use anyhow::Context;
 use clap::{Parser, ValueEnum};
 use errors::Error;
@@ -61,10 +62,17 @@ fn main() -> anyhow::Result<()> {
     // (Note that tokio::io maps AsyncRead of file descriptors to blocking tasks under the hood).
     runtime.shutdown_background();
 
+    tracing::warn!(raw_response = ?result);
     match result {
         Err(Error::ExitCode(code)) => {
             std::process::exit(code);
-        }
+        },
+        Err(e @ Error::EmptyStream) | Err(e @ Error::CheckpointPending) => {
+            // In some cases, we want to let the last error of the connector
+            // be picked up by connector-init as the actual error
+            tracing::warn!(message = e.to_string());
+            std::process::exit(1);
+        },
         Err(err) => Err(err.into()),
         Ok(()) => {
             tracing::info!(message = "atf exiting");

--- a/local-build.sh
+++ b/local-build.sh
@@ -21,6 +21,7 @@ export DOCKER_BUILD_ARCH=amd64
 
 if [ -f "airbyte-integrations/connectors/$connector/requirements.txt" ]; then
    ./tools/bin/setup_connector_venv.sh $connector python3.9
+    export AIRBYTE_TO_FLOW_TAG="dev"
    ./gradlew :airbyte-integrations:connectors:$connector:airbyteDocker
    docker tag docker.io/airbyte/$connector:dev ghcr.io/estuary/$connector:local
 else

--- a/tools/bin/build_image.sh
+++ b/tools/bin/build_image.sh
@@ -44,8 +44,8 @@ if [ "$FOLLOW_SYMLINKS" == "true" ]; then
 else
   JDK_VERSION="${JDK_VERSION:-17.0.1}"
   if [[ -z "${DOCKER_BUILD_PLATFORM}" ]]; then
-    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" . "${args[@]}"
+    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" --build-arg AIRBYTE_TO_FLOW_TAG="$AIRBYTE_TO_FLOW_TAG"  . "${args[@]}"
   else
-    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
+    docker build --build-arg JDK_VERSION="$JDK_VERSION" --build-arg DOCKER_BUILD_ARCH="$DOCKER_BUILD_ARCH" --build-arg AIRBYTE_TO_FLOW_TAG="$AIRBYTE_TO_FLOW_TAG" --platform="$DOCKER_BUILD_PLATFORM" . "${args[@]}"
   fi
 fi


### PR DESCRIPTION
- This removes some of the noise that would obscure the actual error from the connector. Tested with google sheets and the output of this connector becomes this:
```
$ flowctl raw discover ghcr.io/estuary/source-google-sheets:21e4a87 acmeCo
WARNING: The requested image's platform (linux/amd64) does not match the detected host platform (linux/arm64/v8) and no specific platform was requested
 {"ts":"2023-10-27T12:29:06.847252138+00:00","level":"info","message":"connector-init started","fields":{"log_level":"info","module":"connector_init","port":49092}}
{"ts":"2023-10-27T12:29:09.882460709+00:00","level":"info","message":"Running discovery on sheet blah"}
{"ts":"2023-10-27T12:29:10.373776042+00:00","level":"error","message":"Giving up get(...) after 1 tries (googleapiclient.errors.HttpError: <HttpError 404 when requesting https://sheets.googleapis.com/v4/spreadsheets/blah?includeGridData=false&alt=json returned \"Requested entity was not found.\". Details: \"Requested entity was not found.\">)"}
{"ts":"2023-10-27T12:29:10.387711959+00:00","level":"error","message":"Could not run discovery: Requested spreadsheet was not found.\nTraceback (most recent call last):\n  File \"/airbyte/integration_code/google_sheets_source/google_sheets_source.py\", line 107, in discover\n    spreadsheet_metadata = Spreadsheet.parse_obj(client.get(spreadsheetId=spreadsheet_id, includeGridData=False))\n  File \"/usr/local/lib/python3.9/site-packages/backoff/_sync.py\", line 105, in retry\n    ret = target(*args, **kwargs)\n  File \"/airbyte/integration_code/google_sheets_source/client.py\", line 27, in get\n    return self.client.get(**kwargs).execute()\n  File \"/usr/local/lib/python3.9/site-packages/googleapiclient/_helpers.py\", line 130, in positional_wrapper\n    return wrapped(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/site-packages/googleapiclient/http.py\", line 938, in execute\n    raise HttpError(resp, content, uri=self.uri)\ngoogleapiclient.errors.HttpError: <HttpError 404 when requesting https://sheets.googleapis.com/v4/spreadsheets/blah?includeGridData=false&alt=json returned \"Requested entity was not found.\". Details: \"Requested entity was not found.\">\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/airbyte/integration_code/main.py\", line 13, in <module>\n    launch(source, sys.argv[1:])\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 200, in launch\n    for message insource_entrypoint.run(parsed_args):\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 109, in run\n    yield from map(AirbyteEntrypoint.airbyte_message_to_string, self.discover(source_spec, config))\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 144, in discover\n    catalog = self.source.discover(self.logger, config)\n  File \"/airbyte/integration_code/google_sheets_source/google_sheets_source.py\", line 126, in discover\n    raise Exception(f\"Could not run discovery: {reason}\")\nException: Could not run discovery: Requested spreadsheet was not found."}
{"ts":"2023-10-27T12:29:10.461988043+00:00","level":"error","message":"connector failed","fields":{"module":"connector_init::rpc","status":"exit status: 1"}}
Error: connector discover

Caused by:
    status: Internal, message: "Could not run discovery: Requested spreadsheet was not found.\nTraceback (most recent call last):\n  File \"/airbyte/integration_code/google_sheets_source/google_sheets_source.py\", line 107, in discover\n    spreadsheet_metadata = Spreadsheet.parse_obj(client.get(spreadsheetId=spreadsheet_id, includeGridData=False))\n  File \"/usr/local/lib/python3.9/site-packages/backoff/_sync.py\", line 105, in retry\n    ret = target(*args, **kwargs)\n  File \"/airbyte/integration_code/google_sheets_source/client.py\", line 27, in get\n    return self.client.get(**kwargs).execute()\n  File \"/usr/local/lib/python3.9/site-packages/googleapiclient/_helpers.py\", line 130, in positional_wrapper\n    return wrapped(*args, **kwargs)\n  File \"/usr/local/lib/python3.9/site-packages/googleapiclient/http.py\", line 938, in execute\n    raise HttpError(resp, content, uri=self.uri)\ngoogleapiclient.errors.HttpError: <HttpError 404 when requesting https://sheets.googleapis.com/v4/spreadsheets/blah?includeGridData=false&alt=json returned \"Requested entitywas not found.\". Details: \"Requested entity was not found.\">\n\nDuring handling of the above exception, another exception occurred:\n\nTraceback (most recent call last):\n  File \"/airbyte/integration_code/main.py\", line 13, in <module>\n    launch(source, sys.argv[1:])\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 200, in launch\n    for message in source_entrypoint.run(parsed_args):\nFile \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 109, in run\n    yield from map(AirbyteEntrypoint.airbyte_message_to_string, self.discover(source_spec, config))\n  File \"/usr/local/lib/python3.9/site-packages/airbyte_cdk/entrypoint.py\", line 144, in discover\n    catalog = self.source.discover(self.logger, config)\n  File \"/airbyte/integration_code/google_sheets_source/google_sheets_source.py\", line 126, in discover\n    raise Exception(f\"Could not run discovery: {reason}\")\nException: Could not run discovery: Requested spreadsheet was not found.", details: [], metadata: MetadataMap { headers: {"last-log-bin": "GgwIltruqQYQ14fwuAEgASrhD0NvdWxkIG5vdCBydW4gZGlzY292ZXJ5OiBSZXF1ZXN0ZWQgc3ByZWFkc2hlZXQgd2FzIG5vdCBmb3VuZC4KVHJhY2ViYWNrIChtb3N0IHJlY2VudCBjYWxsIGxhc3QpOgogIEZpbGUgIi9haXJieXRlL2ludGVncmF0aW9uX2NvZGUvZ29vZ2xlX3NoZWV0c19zb3VyY2UvZ29vZ2xlX3NoZWV0c19zb3VyY2UucHkiLCBsaW5lIDEwNywgaW4gZGlzY292ZXIKICAgIHNwcmVhZHNoZWV0X21ldGFkYXRhID0gU3ByZWFkc2hlZXQucGFyc2Vfb2JqKGNsaWVudC5nZXQoc3ByZWFkc2hlZXRJZD1zcHJlYWRzaGVldF9pZCwgaW5jbHVkZUdyaWREYXRhPUZhbHNlKSkKICBGaWxlICIvdXNyL2xvY2FsL2xpYi9weXRob24zLjkvc2l0ZS1wYWNrYWdlcy9iYWNrb2ZmL19zeW5jLnB5IiwgbGluZSAxMDUsIGluIHJldHJ5CiAgICByZXQgPSB0YXJnZXQoKmFyZ3MsICoqa3dhcmdzKQogIEZpbGUgIi9haXJieXRlL2ludGVncmF0aW9uX2NvZGUvZ29vZ2xlX3NoZWV0c19zb3VyY2UvY2xpZW50LnB5IiwgbGluZSAyNywgaW4gZ2V0CiAgICByZXR1cm4gc2VsZi5jbGllbnQuZ2V0KCoqa3dhcmdzKS5leGVjdXRlKCkKICBGaWxlICIvdXNyL2xvY2FsL2xpYi9weXRob24zLjkvc2l0ZS1wYWNrYWdlcy9nb29nbGVhcGljbGllbnQvX2hlbHBlcnMucHkiLCBsaW5lIDEzMCwgaW4gcG9zaXRpb25hbF93cmFwcGVyCiAgICByZXR1cm4gd3JhcHBlZCgqYXJncywgKiprd2FyZ3MpCiAgRmlsZSAiL3Vzci9sb2NhbC9saWIvcHl0aG9uMy45L3NpdGUtcGFja2FnZXMvZ29vZ2xlYXBpY2xpZW50L2h0dHAucHkiLCBsaW5lIDkzOCwgaW4gZXhlY3V0ZQogICAgcmFpc2UgSHR0cEVycm9yKHJlc3AsIGNvbnRlbnQsIHVyaT1zZWxmLnVyaSkKZ29vZ2xlYXBpY2xpZW50LmVycm9ycy5IdHRwRXJyb3I6IDxIdHRwRXJyb3IgNDA0IHdoZW4gcmVxdWVzdGluZyBodHRwczovL3NoZWV0cy5nb29nbGVhcGlzLmNvbS92NC9zcHJlYWRzaGVldHMvYmxhaD9pbmNsdWRlR3JpZERhdGE9ZmFsc2UmYWx0PWpzb24gcmV0dXJuZWQgIlJlcXVlc3RlZCBlbnRpdHkgd2FzIG5vdCBmb3VuZC4iLiBEZXRhaWxzOiAiUmVxdWVzdGVkIGVudGl0eSB3YXMgbm90IGZvdW5kLiI+CgpEdXJpbmcgaGFuZGxpbmcgb2YgdGhlIGFib3ZlIGV4Y2VwdGlvbiwgYW5vdGhlciBleGNlcHRpb24gb2NjdXJyZWQ6CgpUcmFjZWJhY2sgKG1vc3QgcmVjZW50IGNhbGwgbGFzdCk6CiAgRmlsZSAiL2FpcmJ5dGUvaW50ZWdyYXRpb25fY29kZS9tYWluLnB5IiwgbGluZSAxMywgaW4gPG1vZHVsZT4KICAgIGxhdW5jaChzb3VyY2UsIHN5cy5hcmd2WzE6XSkKICBGaWxlICIvdXNyL2xvY2FsL2xpYi9weXRob24zLjkvc2l0ZS1wYWNrYWdlcy9haXJieXRlX2Nkay9lbnRyeXBvaW50LnB5IiwgbGluZSAyMDAsIGluIGxhdW5jaAogICAgZm9yIG1lc3NhZ2UgaW4gc291cmNlX2VudHJ5cG9pbnQucnVuKHBhcnNlZF9hcmdzKToKICBGaWxlICIvdXNyL2xvY2FsL2xpYi9weXRob24zLjkvc2l0ZS1wYWNrYWdlcy9haXJieXRlX2Nkay9lbnRyeXBvaW50LnB5IiwgbGluZSAxMDksIGluIHJ1bgogICAgeWllbGQgZnJvbSBtYXAoQWlyYnl0ZUVudHJ5cG9pbnQuYWlyYnl0ZV9tZXNzYWdlX3RvX3N0cmluZywgc2VsZi5kaXNjb3Zlcihzb3VyY2Vfc3BlYywgY29uZmlnKSkKICBGaWxlICIvdXNyL2xvY2FsL2xpYi9weXRob24zLjkvc2l0ZS1wYWNrYWdlcy9haXJieXRlX2Nkay9lbnRyeXBvaW50LnB5IiwgbGluZSAxNDQsIGluIGRpc2NvdmVyCiAgICBjYXRhbG9nID0gc2VsZi5zb3VyY2UuZGlzY292ZXIoc2VsZi5sb2dnZXIsIGNvbmZpZykKICBGaWxlICIvYWlyYnl0ZS9pbnRlZ3JhdGlvbl9jb2RlL2dvb2dsZV9zaGVldHNfc291cmNlL2dvb2dsZV9zaGVldHNfc291cmNlLnB5IiwgbGluZSAxMjYsIGluIGRpc2NvdmVyCiAgICByYWlzZSBFeGNlcHRpb24oZiJDb3VsZCBub3QgcnVuIGRpc2NvdmVyeToge3JlYXNvbn0iKQpFeGNlcHRpb246IENvdWxkIG5vdCBydW4gZGlzY292ZXJ5OiBSZXF1ZXN0ZWQgc3ByZWFkc2hlZXQgd2FzIG5vdCBmb3VuZC4"} }
```