### PR TITLE
source-airtable: OAuth2.0 removed

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/Dockerfile
+++ b/airbyte-integrations/connectors/source-airtable/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-airtable:3.0.0
+FROM airbyte/source-airtable:3.1.0
 
 COPY *.json ./
 COPY streams/* ./streams/

--- a/airbyte-integrations/connectors/source-airtable/spec.patch.json
+++ b/airbyte-integrations/connectors/source-airtable/spec.patch.json
@@ -7,46 +7,6 @@
       },
       "oneOf": [
         {
-          "type": "object",
-          "title": "OAuth2.0",
-          "x-oauth2-provider": "airtable",
-          "required": ["client_id", "client_secret", "refresh_token"],
-          "properties": {
-            "auth_method": {
-              "type": "string",
-              "const": "oauth2.0",
-              "default": "oauth2.0"
-            },
-            "client_id": {
-              "type": "string",
-              "title": "Client ID",
-              "description": "The client ID of the Airtable developer application.",
-              "airbyte_secret": true
-            },
-            "client_secret": {
-              "type": "string",
-              "title": "Client secret",
-              "description": "The client secret the Airtable developer application.",
-              "airbyte_secret": true
-            },
-            "access_token": {
-              "type": "string",
-              "description": "Access Token for making authenticated requests.",
-              "airbyte_secret": true
-            },
-            "token_expiry_date": {
-              "type": "string",
-              "description": "The date-time when the access token should be refreshed."
-            },
-            "refresh_token": {
-              "type": "string",
-              "title": "Refresh token",
-              "description": "The key to refresh the expired access token.",
-              "airbyte_secret": true
-            }
-          }
-        },
-        {
           "title": "Personal Access Token",
           "type": "object",
           "required": ["api_key"],
@@ -58,7 +18,7 @@
             },
             "api_key": {
               "type": "string",
-              "description": "The Personal Access Token for the Airtable account. See the <a href=\"https://airtable.com/developers/web/guides/personal-access-tokens\">Support Guide</a> for more information on how to obtain this token.",
+              "description": "The Personal Access Token for the Airtable account. See https://airtable.com/developers/web/guides/personal-access-tokens for more information on how to obtain this token.",
               "title": "Personal Access Token",
               "airbyte_secret": true,
               "examples": ["key1234567890"]


### PR DESCRIPTION
OAuth2.0 has been removed from source-airtable connector as it was showing 400 error after the token expires. 