### PR TITLE
fix nonstandard format filtering

### DIFF
--- a/airbyte-to-flow/src/interceptors/fix_document_schema.rs
+++ b/airbyte-to-flow/src/interceptors/fix_document_schema.rs
@@ -188,7 +188,7 @@ pub fn fix_nonstandard_jsonschema_attributes(schema: &mut serde_json::Value) {
                 if f == "int32" || f == "int64" {
                     // Insert updates values
                     map.insert("format".to_string(), json!("integer"));
-                } else if let Err(_) = serde_json::from_str::<Format>(f) {
+                } else if let Err(_) = serde_json::from_value::<Format>(serde_json::Value::String(f.to_string())) {
                     // a non-standard format output by salesforce connector
                     map.remove("format");
                 }
@@ -535,7 +535,7 @@ mod test {
                             "items": {
                                 "group": "x",
                                 "type": "string",
-                                "format": "random"
+                                "format": "date-time"
                             }
                         },
                         "airbyte_type": {
@@ -568,7 +568,8 @@ mod test {
                             "group": {
                                 "type": "array",
                                 "items": {
-                                    "type": "string"
+                                    "type": "string",
+                                    "format": "date-time"
                                 }
                             },
                             "airbyte_type": {


### PR DESCRIPTION
The change from `from_value` to `from_str` was made since we thought they are equivalent, but they are not, as `from_str` requires a wrapped string. This was causing all `format` stanzas to be removed.

See https://github.com/estuary/airbyte/pull/275#discussion_r1372341249 for context