### PR TITLE
source-airtable: update tag of source image to one that exists

### DIFF
--- a/airbyte-integrations/connectors/source-airtable/Dockerfile
+++ b/airbyte-integrations/connectors/source-airtable/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-airtable:3.1.0
+FROM airbyte/source-airtable:3.0.1
 
 COPY *.json ./
 COPY streams/* ./streams/


### PR DESCRIPTION
The image tag that was used in the Dockerfile was incorrect, and resulted in failure to build the image. I'm assuming the version components were just accidentally transposed, so I updated it to `3.0.1` instead of the latest version.