### PR TITLE
make source-google-analytics connectors free to use on estuary

### DIFF
--- a/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-data-api/Dockerfile
@@ -16,3 +16,4 @@ LABEL io.airbyte.name=airbyte/source-google-analytics-data-api
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
 LABEL FLOW_RUNTIME_CODEC=json
+LABEL dev.estuary.usage-rate=0.0

--- a/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
+++ b/airbyte-integrations/connectors/source-google-analytics-v4/Dockerfile
@@ -16,3 +16,4 @@ LABEL io.airbyte.name=airbyte/source-google-analytics-v4
 LABEL FLOW_RUNTIME_PROTOCOL=capture
 LABEL CONNECTOR_PROTOCOL=flow-capture
 LABEL FLOW_RUNTIME_CODEC=json
+LABEL dev.estuary.usage-rate=0.0


### PR DESCRIPTION
Goes along with estuary/flow#1403 and estuary/connectors#1321