### PR TITLE
Upgrade source-jira version

### DIFF
--- a/airbyte-integrations/connectors/source-jira/Dockerfile
+++ b/airbyte-integrations/connectors/source-jira/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-jira:0.3.9
+FROM airbyte/source-jira:1.2.0
 
 COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]


### PR DESCRIPTION
Upgrading Jira version to Airbyte latest. Confirmed that upgrade will ignore boards that do not have sprints configured instead of exiting the connector.

New Streams:

- Issue custom field options
- IssueTypes
- Project Roles