### PR TITLE
Upgrading Chargebee capture to 0.6.4

### DIFF
--- a/airbyte-integrations/connectors/source-chargebee/Dockerfile
+++ b/airbyte-integrations/connectors/source-chargebee/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-chargebee:0.2.3
+FROM airbyte/source-chargebee:0.6.4
 
 COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]


### PR DESCRIPTION
Upgrading Chargebee capture to 0.6.4 to support custom_fields