### PR TITLE
support omitted streams

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/omitted_streams.json
+++ b/airbyte-integrations/connectors/source-greenhouse/omitted_streams.json
@@ -1,0 +1,3 @@
+[
+    "activity_feed"
+]


### PR DESCRIPTION
The `activity_feed` stream in `source-greenhouse` is an array API response that should be flattened, but the Airbyte connector emits it as-is. An abbreviated example response is below:
```json
{
  "notes": [
    {
      "id": 1,
    }
  ],
  "emails": [
    {
      "id": 1,
    }
  ],
  "activities": [
    {
      "id": 1,
    },
    {
      "id": 2,
    }
  ]
}

```
The real solution is to fix the connector so individual objects from the response arrays are emitted instead of emitting the entire response as as single document. However, until the connector is fixed, omitting `activity_feed` from discovery is a temporary fix.

We previously had the capability to omit streams from discovery with `selected_streams.json`, but we changed it to specify streams that should be enabled & disabled everything else. To re-add the capability to completely omit streams from discovery, this PR adds `omitted_streams.json`.

I tested this locally with `source-greenhouse`, and `activity_feed` is omitted from discovery.