### PR TITLE
source-greenhouse: patch applications schema

### DIFF
--- a/airbyte-integrations/connectors/source-greenhouse/streams/applications.patch.json
+++ b/airbyte-integrations/connectors/source-greenhouse/streams/applications.patch.json
@@ -1,5 +1,16 @@
 {
     "properties": {
+            "credited_to": {
+                "type": ["object", "null"],
+                "properties": {
+                    "id": {
+                        "type": ["integer", "null"]
+                    }
+                }
+            },
+            "location": {
+                "type": ["object", "string", "null"]
+            },
             "prospective_department":{
                 "type": ["object", "null"]
             },
@@ -15,6 +26,9 @@
                         "type": ["object", "null"]
                     }
                 }
-        }
+            },
+            "source": {
+                "type": ["object", "null"]
+            }
     }
 }


### PR DESCRIPTION
Patching the `applications` schema to address schema violations stopping a new production task.

There may need to be further patches for other streams (I suspect `source-greenhouse` has gotten much use before now), but these `applications` schema patches should allow the task to at least finish that stream.