### PR TITLE
source-bing-ads: bump to version 0.1.24

### DIFF
--- a/airbyte-integrations/connectors/source-bing-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-bing-ads/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-bing-ads:0.1.19
+FROM airbyte/source-bing-ads:0.1.24
 
 COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]


### PR DESCRIPTION
This version bump from 0.1.19 to 0.1.24 adds retries for temporary DNS resolution failures & a lookback window capability. Some fields are also added to a few streams, but none are removed so this this bump is backwards compatible.