### PR TITLE
source-marketo: limit which streams are enabled after discovery

### DIFF
--- a/airbyte-integrations/connectors/source-marketo/selected_streams.json
+++ b/airbyte-integrations/connectors/source-marketo/selected_streams.json
@@ -1,0 +1,7 @@
+[
+    "activity_types",
+    "campaigns",
+    "lists",
+    "leads",
+    "programs"
+]


### PR DESCRIPTION
We've observed issues with the the conditional discovery logic for all the `activity_foobar` bindings. It's not reliable, so sometimes these bindings are discovered and sometimes they aren't. If these bindings disappear when they were disabled then are re-discovered later as enabled, that could blow up certain API limits. To avoid that, I'm choosing to only enable the bindings that are consistently discovered, and the remaining conditionally discovered bindings are disabled.

Tested on a local stack and confirmed that all the `activity_foobar` bindings are discovered as disabled.