### PR TITLE
source-google-sheets: add debug logs to troubleshoot missing `properties` field

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/google_sheets_source.py
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/google_sheets_source.py
@@ -134,7 +134,7 @@ class GoogleSheetsSource(Source):
     ) -> Generator[AirbyteMessage, None, None]:
         client = GoogleSheetsClient(self.get_credentials(config))
 
-        sheet_to_column_name = Helpers.parse_sheet_and_column_names_from_catalog(catalog)
+        sheet_to_column_name = Helpers.parse_sheet_and_column_names_from_catalog(catalog, logger)
         spreadsheet_id = Helpers.get_spreadsheet_id(config["spreadsheet_id"])
 
         row_batch_size = config.get("row_batch_size", ROW_BATCH_SIZE)

--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/helpers.py
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/helpers.py
@@ -119,11 +119,13 @@ class Helpers(object):
         return Helpers.get_formatted_row_values(first_row_data)
 
     @staticmethod
-    def parse_sheet_and_column_names_from_catalog(catalog: ConfiguredAirbyteCatalog) -> Dict[str, FrozenSet[str]]:
+    def parse_sheet_and_column_names_from_catalog(catalog: ConfiguredAirbyteCatalog, logger: AirbyteLogger) -> Dict[str, FrozenSet[str]]:
         sheet_to_column_name = {}
+        logger.debug("Parsing sheet and column names from catalog.")
         for configured_stream in catalog.streams:
             stream = configured_stream.stream
             sheet_name = stream.name
+            logger.debug(f"Attempting to parse sheet {sheet_name}. stream: {stream}, stream.json_schema: {stream.json_schema}")
             sheet_to_column_name[sheet_name] = frozenset(stream.json_schema["properties"].keys())
 
         return sheet_to_column_name

--- a/airbyte-integrations/connectors/source-google-sheets/unit_tests/test_helpers.py
+++ b/airbyte-integrations/connectors/source-google-sheets/unit_tests/test_helpers.py
@@ -145,7 +145,7 @@ class TestHelpers(unittest.TestCase):
             ]
         )
 
-        actual = Helpers.parse_sheet_and_column_names_from_catalog(catalog)
+        actual = Helpers.parse_sheet_and_column_names_from_catalog(catalog, logger)
 
         expected = {sheet1: sheet1_columns, sheet2: sheet2_columns}
         self.assertEqual(actual, expected)


### PR DESCRIPTION
Captures have started hitting `KeyError`s because the `properties` field is missing on the stream's JSON schema. I haven't been able to replicate this locally, so this logging is suppose to help figure out what that dictionary looks like for captures hitting the error.