### PR TITLE
source-google-sheets: switch to info level logging

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/helpers.py
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/helpers.py
@@ -121,11 +121,11 @@ class Helpers(object):
     @staticmethod
     def parse_sheet_and_column_names_from_catalog(catalog: ConfiguredAirbyteCatalog, logger: AirbyteLogger) -> Dict[str, FrozenSet[str]]:
         sheet_to_column_name = {}
-        logger.debug("Parsing sheet and column names from catalog.")
+        logger.info("Parsing sheet and column names from catalog.")
         for configured_stream in catalog.streams:
             stream = configured_stream.stream
             sheet_name = stream.name
-            logger.debug(f"Attempting to parse sheet {sheet_name}. stream: {stream}, stream.json_schema: {stream.json_schema}")
+            logger.info(f"Attempting to parse sheet {sheet_name}. stream: {stream}, stream.json_schema: {stream.json_schema}")
             sheet_to_column_name[sheet_name] = frozenset(stream.json_schema["properties"].keys())
 
         return sheet_to_column_name


### PR DESCRIPTION
For some reason, debug logging isn't showing up when setting `shards: {"logLevel": "debug"}` on captures. For the sake of just getting something logged quickly, I'm changing these to info level logs while I troubleshoot.