### PR TITLE
source-google-sheets: update properties location in JSON schema

### DIFF
--- a/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/helpers.py
+++ b/airbyte-integrations/connectors/source-google-sheets/google_sheets_source/helpers.py
@@ -121,12 +121,11 @@ class Helpers(object):
     @staticmethod
     def parse_sheet_and_column_names_from_catalog(catalog: ConfiguredAirbyteCatalog, logger: AirbyteLogger) -> Dict[str, FrozenSet[str]]:
         sheet_to_column_name = {}
-        logger.info("Parsing sheet and column names from catalog.")
         for configured_stream in catalog.streams:
             stream = configured_stream.stream
             sheet_name = stream.name
-            logger.info(f"Attempting to parse sheet {sheet_name}. stream: {stream}, stream.json_schema: {stream.json_schema}")
-            sheet_to_column_name[sheet_name] = frozenset(stream.json_schema["properties"].keys())
+            properties = stream.json_schema["$defs"]["flow://connector-schema"]["properties"]
+            sheet_to_column_name[sheet_name] = frozenset(properties.keys())
 
         return sheet_to_column_name
 


### PR DESCRIPTION
Commit [1b7eff0e5ecf774ee84f773caa6bda213afa21f8 in estuary/flow](https://github.com/estuary/flow/commit/1b7eff0e5ecf774ee84f773caa6bda213afa21f8) changed where properties live within the JSON schema. `source-google-sheets` needs to look in the new location for properties, otherwise the connector will crash with a `KeyError`.

For reference, this is what `stream.json_schema` looks like in `parse_sheet_and_column_names_from_catalog`:
```json
{
  "$defs": {
    "flow://connector-schema": {
      "$id": "flow://connector-schema",
      "$schema": "http://json-schema.org/draft-07/schema#",
      "properties": {
        "my_field": {
          "type": "string"
        },
        "another_field": {
          "type": "string"
        },
        "row_id": {
          "type": "integer"
        }
      },
      "required": [
        "row_id"
      ],
      "type": "object"
    }
  },
  "$ref": "flow://connector-schema"
}
```