### PR TITLE
Fixing redundancy in the airbyte_to_flow step in GitHub Actions

### DIFF
--- a/.github/workflows/connectors.yml
+++ b/.github/workflows/connectors.yml
@@ -21,7 +21,7 @@ jobs:
               - 'airbyte-to-flow/**'
   airbyte_to_flow:
     runs-on: ubuntu-24.04
-
+    if: needs.paths-filter.outputs.atf_modified == 'true'
     permissions:
       contents: read
       packages: write
@@ -33,13 +33,11 @@ jobs:
 
     steps:
       - uses: actions/checkout@v2
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         with:
           fetch-depth: 0
 
       - name: Prepare
         id: prep
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         run: |
           TAG=$(echo $GITHUB_SHA | head -c7)
           echo ::set-output name=tag::${TAG}
@@ -47,7 +45,6 @@ jobs:
       # Linux builds need the non-default musl target.
       - name: Install Rust
         uses: actions-rs/toolchain@v1
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         with:
           toolchain: stable
           target: x86_64-unknown-linux-musl
@@ -55,7 +52,6 @@ jobs:
           override: true
 
       - uses: actions/cache@v3
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         with:
           path: |
             ~/.cargo/bin/
@@ -66,11 +62,9 @@ jobs:
           key: ${{ runner.os }}-cargo-${{ hashFiles('**/Cargo.lock') }}
 
       - name: Install protobuf compiler (it's not already included in CI runner)
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         run: sudo apt install -y libprotobuf-dev protobuf-compiler
 
       - name: Build Linux
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         run: |-
           sudo apt-get update && \
           sudo apt-get install -y musl-tools && \
@@ -78,15 +72,12 @@ jobs:
           make
 
       - name: Tests
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         run: cd airbyte-to-flow && cargo test --release --target x86_64-unknown-linux-musl
 
       - name: Set up Docker Buildx
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         uses: docker/setup-buildx-action@v2
 
       - name: Login to GitHub Container Registry
-        if: needs.paths-filter.outputs.atf_modified == 'true'
         uses: docker/login-action@v2
         with:
           registry: ghcr.io
@@ -95,7 +86,7 @@ jobs:
 
       - name: Build and push (dev and commit tag)
         uses: docker/build-push-action@v3
-        if: needs.paths-filter.outputs.atf_modified == 'true' && github.ref == 'refs/heads/master'
+        if: github.ref == 'refs/heads/master'
         with:
           context: airbyte-to-flow
           platforms: linux/amd64
@@ -104,7 +95,7 @@ jobs:
 
       - name: Build and push (commit tag)
         uses: docker/build-push-action@v3
-        if: needs.paths-filter.outputs.atf_modified == 'true' && github.ref != 'refs/heads/master'
+        if: github.ref != 'refs/heads/master'
         with:
           context: airbyte-to-flow
           platforms: linux/amd64


### PR DESCRIPTION
## PR Title  
**Refactor `airbyte_to_flow` job to use general conditional (DRY)**  

## Description  

### Summary  
This PR refactors the **`airbyte_to_flow`** step in the GitHub Actions pipeline by removing repeated conditional checks.  

### Details  
- Previously, multiple steps repeated the condition:  
  ```yaml
  if: needs.paths-filter.outputs.atf_modified == 'true'
To follow the DRY principle, I moved this into a general job-level conditional instead of repeating it at each step.

### Benefits

Cleaner and more maintainable workflow file.

Reduces redundancy and potential errors from duplicated conditions.