### PR TITLE
source-amazon-ads: bump version to 7.3.1

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
+++ b/airbyte-integrations/connectors/source-amazon-ads/Dockerfile
@@ -1,7 +1,7 @@
 ARG AIRBYTE_TO_FLOW_TAG="dev"
 FROM ghcr.io/estuary/airbyte-to-flow:$AIRBYTE_TO_FLOW_TAG as airbyte-to-flow
 
-FROM airbyte/source-amazon-ads:3.0.0
+FROM airbyte/source-amazon-ads:7.3.1
 
 COPY --from=airbyte-to-flow /airbyte-to-flow ./
 ENTRYPOINT ["/airbyte/integration_code/airbyte-to-flow", "--connector-entrypoint", "python /airbyte/integration_code/main.py"]


### PR DESCRIPTION
**Description:**

Fixes captures attempting to use the deprecated `adGroups` endpoint:

```
Request URL: https://advertising-api.amazon.com/v2/sp/adGroups?count=100, Response Code: 429, Response Text: {"code":"429","details":"Throttled - Deprecated resource. Please use a newer API
```

~No breaking changes. 5.0.20 was picked because the next version, 6.0.0, removes the `SponsoredBrandsVideoReportStream` and `SponsoredBrandsReportStream` streams that we currently have in use.~

~`"default": null`s have been added to all deprecated fields. We understand this to keep them visible for materialisations — even if no more data will be produced, existing information should remain reachable.~

Version 5.0.20 included deprecated endpoints, so a seamless transition was impossible. We'll instead bump to the latest available version as an interim measure until we can write a native connector.
