### PR TITLE
ci: re-queue connector tags over PostgREST instead of direct psql

### DIFF
--- a/.github/workflows/connectors.yml
+++ b/.github/workflows/connectors.yml
@@ -245,42 +245,54 @@ jobs:
           docker tag ghcr.io/estuary/${{ matrix.connector.name }}:${{ steps.prep.outputs.tag }} ghcr.io/estuary/${{ matrix.connector.alias }}:$IMAGE_VERSION
           docker push ghcr.io/estuary/${{ matrix.connector.alias }}:$IMAGE_VERSION
 
-      - name: Install psql
-        if: ${{ github.event_name == 'push' }}
-        run: |
-          sudo apt update
-          sudo apt install postgresql
-
-      - name: Refresh connector tags for ${{ matrix.connector.name }}
+      # Re-queue connector tag publishing over PostgREST (HTTPS) instead of a direct
+      # psql connection from CI.
+      - name: Re-queue connector tags for ${{ matrix.connector.name }}
         if: ${{ github.event_name == 'push' }}
         env:
-          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
-          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
-          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
-          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
+          RT_ID: ${{ secrets.CONNECTOR_REFRESH_RT_ID }}
+          RT_SECRET: ${{ secrets.CONNECTOR_REFRESH_RT_SECRET }}
         run: |
+          set -euo pipefail
           source tools/lib/lib.sh
           export VERSION=$(_get_docker_image_version airbyte-integrations/connectors/${{ matrix.connector.name }}/Dockerfile)
-          echo "UPDATE public.connector_tags SET job_status='{\"type\": \"queued\"}'
-                  WHERE connector_id IN (
-                    SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${{ matrix.connector.name }}'
-                  )
-                  AND
-                  image_tag IN (':$VERSION', ':dev');" | psql
+          SUPABASE_URL="https://eyrcnmuzzyriypdajwdk.supabase.co"
+          # Public anon key, used only as the PostgREST apikey header.
+          ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco"
 
-      - name: Refresh connector tags for ${{ matrix.connector.alias }}
+          access_token=$(curl -sS -X POST "$SUPABASE_URL/rest/v1/rpc/generate_access_token" \
+            -H "apikey: $ANON_KEY" -H "Content-Type: application/json" \
+            -d "{\"refresh_token_id\": \"$RT_ID\", \"secret\": \"$RT_SECRET\"}" | jq -r '.access_token')
+          if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+            echo "failed to obtain control-plane access token"; exit 1
+          fi
+
+          curl -sS --fail-with-body -X POST "$SUPABASE_URL/rest/v1/rpc/requeue_connector_tag" \
+            -H "apikey: $ANON_KEY" -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" \
+            -d "{\"image_name\": \"ghcr.io/estuary/${{ matrix.connector.name }}\", \"image_tags\": [\":$VERSION\", \":dev\"]}"
+
+      - name: Re-queue connector tags for ${{ matrix.connector.alias }}
         if: github.event_name == 'push' && matrix.connector.alias
         env:
-          PGHOST: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_HOST }}
-          PGUSER: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_USER }}
-          PGPASSWORD: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_PASSWORD }}
-          PGDATABASE: ${{ secrets.POSTGRES_CONNECTOR_REFRESH_DATABASE }}
+          RT_ID: ${{ secrets.CONNECTOR_REFRESH_RT_ID }}
+          RT_SECRET: ${{ secrets.CONNECTOR_REFRESH_RT_SECRET }}
         run: |
+          set -euo pipefail
           source tools/lib/lib.sh
           export VERSION=$(_get_docker_image_version airbyte-integrations/connectors/${{ matrix.connector.name }}/Dockerfile)
-          echo "UPDATE public.connector_tags SET job_status='{\"type\": \"queued\"}'
-                  WHERE connector_id IN (
-                    SELECT id FROM connectors WHERE image_name='ghcr.io/estuary/${{ matrix.connector.alias }}'
-                  )
-                  AND
-                  image_tag IN (':$VERSION', ':dev');" | psql
+          SUPABASE_URL="https://eyrcnmuzzyriypdajwdk.supabase.co"
+          # Public anon key, used only as the PostgREST apikey header.
+          ANON_KEY="eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImV5cmNubXV6enlyaXlwZGFqd2RrIiwicm9sZSI6ImFub24iLCJpYXQiOjE2NDg3NTA1NzksImV4cCI6MTk2NDMyNjU3OX0.y1OyXD3-DYMz10eGxzo1eeamVMMUwIIeOoMryTRAoco"
+
+          access_token=$(curl -sS -X POST "$SUPABASE_URL/rest/v1/rpc/generate_access_token" \
+            -H "apikey: $ANON_KEY" -H "Content-Type: application/json" \
+            -d "{\"refresh_token_id\": \"$RT_ID\", \"secret\": \"$RT_SECRET\"}" | jq -r '.access_token')
+          if [ -z "$access_token" ] || [ "$access_token" = "null" ]; then
+            echo "failed to obtain control-plane access token"; exit 1
+          fi
+
+          curl -sS --fail-with-body -X POST "$SUPABASE_URL/rest/v1/rpc/requeue_connector_tag" \
+            -H "apikey: $ANON_KEY" -H "Authorization: Bearer $access_token" \
+            -H "Content-Type: application/json" \
+            -d "{\"image_name\": \"ghcr.io/estuary/${{ matrix.connector.alias }}\", \"image_tags\": [\":$VERSION\", \":dev\"]}"


### PR DESCRIPTION
**Description:**

Replaces the direct psql re-queue of `connector_tags` in `.github/workflows/connectors.yml` (both the connector-name and alias blocks) with authenticated calls to the control-plane API (PostgREST over HTTPS), so connector publishes no longer require a direct database connection from CI. Each block exchanges a revocable refresh token for a short-lived access token whose `role` claim is `github_action_connector_refresh`, then calls the `requeue_connector_tag` RPC.

**Depends on (draft until both are done):**

- estuary/flow#3013 (adds `requeue_connector_tag` and the scoped-role wiring) deployed first.
- New repo secrets `CONNECTOR_REFRESH_RT_ID` and `CONNECTOR_REFRESH_RT_SECRET`, minted via `create_scoped_refresh_token('github_action_connector_refresh', ...)`.

Replaces the `POSTGRES_CONNECTOR_REFRESH_*` secrets, which can be removed after cutover.

**Notes for reviewers:**

- No new database permissions: the same `connector_tags.job_status` UPDATE the role already holds.
- Kept as a draft until flow#3013 is deployed and the secrets are set.
