### PR TITLE
atf: update to latest flow protocol

### DIFF
--- a/airbyte-to-flow/Cargo.lock
+++ b/airbyte-to-flow/Cargo.lock
@@ -59,7 +59,7 @@ dependencies = [
  "prost",
  "proto-flow",
  "regex",
- "schemars",
+ "schemars 0.8.22",
  "serde",
  "serde_json",
  "structopt",
@@ -192,22 +192,18 @@ dependencies = [
 
 [[package]]
 name = "base64"
-version = "0.13.1"
+version = "0.22.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9e1b586273c5702936fe7b7d6896644d8be71e6314cfe09d3167c95f712589e8"
-
-[[package]]
-name = "base64"
-version = "0.21.7"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9d297deb1925b89f2ccc13d7635fa0714f12c87adce1c75356b39ca9b7178567"
+checksum = "72b3254f16251a8381aa12e40e3c4d2f0199f8c6508fbecb9d91f575e0fbb8c6"
 
 [[package]]
 name = "bigdecimal"
-version = "0.3.1"
+version = "0.4.8"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a6773ddc0eafc0e509fb60e48dff7f450f8e674a0686ae8605e8d9901bd5eefa"
+checksum = "1a22f228ab7a1b23027ccc6c350b72868017af7ea8356fbdf19f8d991c690013"
 dependencies = [
+ "autocfg",
+ "libm",
  "num-bigint",
  "num-integer",
  "num-traits",
@@ -227,9 +223,9 @@ checksum = "2261d10cca569e4643e526d8dc2e62e433cc8aba21ab764233731f8d369bf394"
 
 [[package]]
 name = "bitvec"
-version = "0.19.6"
+version = "1.0.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "55f93d0ef3363c364d5976646a38f04cf67cfe1d4c8d160cdea02cab2c116b33"
+checksum = "1bc2832c24239b0141d5674bb9174f9d68a8b5b3f2753311927c172ca46f7e9c"
 dependencies = [
  "funty",
  "radium",
@@ -544,25 +540,25 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1e5bb8c90dca5c87780b3e93863f7ab3df7dfb8a"
+source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
 dependencies = [
- "base64 0.13.1",
+ "base64",
  "bigdecimal",
  "bumpalo",
  "bytes",
  "futures",
- "fxhash",
- "itertools 0.10.5",
+ "highway",
+ "itertools",
  "json",
  "proto-gazette",
  "regex",
  "rkyv",
- "schemars",
+ "schemars 1.2.1",
  "serde",
  "serde_json",
  "sha2",
  "tempfile",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "time",
  "tracing",
  "tuple",
@@ -601,7 +597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -625,7 +621,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 [[package]]
 name = "flow_cli_common"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1e5bb8c90dca5c87780b3e93863f7ab3df7dfb8a"
+source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
 dependencies = [
  "anyhow",
  "atty",
@@ -641,6 +637,12 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3f9eec918d3f24069decb9af1554cad7c880e2da24a9afd88aca000531ab82c1"
 
 [[package]]
+name = "foldhash"
+version = "0.1.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9c4f5dac5e15c24eb999c26181a6ca40b39fe946cbe4c263c7209467bc83af2"
+
+[[package]]
 name = "form_urlencoded"
 version = "1.2.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -651,9 +653,9 @@ dependencies = [
 
 [[package]]
 name = "funty"
-version = "1.1.0"
+version = "2.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fed34cd105917e91daa4da6b3728c47b068749d6a62c59811f06ed2ac71d9da7"
+checksum = "e6d5a32815ae3f33302d95fdcb2ce17862f8c65363dcfd29360480ba1001fc9c"
 
 [[package]]
 name = "futures"
@@ -745,15 +747,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "fxhash"
-version = "0.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c31b6d751ae2c7f11320402d34e41349dd1016f8d5d45e48c4312bc8625af50c"
-dependencies = [
- "byteorder",
-]
-
-[[package]]
 name = "generic-array"
 version = "0.14.7"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -792,12 +785,9 @@ name = "hashbrown"
 version = "0.15.5"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "9229cfe53dfd69f0609a49f65461bd93001ea1ef889cd5529dd176593f5338a1"
-
-[[package]]
-name = "hashbrown"
-version = "0.16.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5419bdc4f6a9207fbeba6d11b604d481addf78ecd10c11ad51e76c2f6482748d"
+dependencies = [
+ "foldhash",
+]
 
 [[package]]
 name = "heck"
@@ -828,6 +818,12 @@ checksum = "62b467343b94ba476dcb2500d242dadbb39557df889310ac77c5d99100aaac33"
 dependencies = [
  "libc",
 ]
+
+[[package]]
+name = "highway"
+version = "1.3.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "9040319a6910b901d5d49cbada4a99db52836a1b63228a05f7e2b7f8feef89b1"
 
 [[package]]
 name = "iana-time-zone"
@@ -983,7 +979,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4b0f83760fb341a774ed326568e19f5a863af4a952def8c39f9ab92fd95b88e5"
 dependencies = [
  "equivalent",
- "hashbrown 0.16.0",
+ "hashbrown 0.15.5",
 ]
 
 [[package]]
@@ -1026,24 +1022,6 @@ checksum = "7943c866cc5cd64cbc25b2e01621d07fa8eb2a1a23160ee81ce38704e97b8ecf"
 
 [[package]]
 name = "itertools"
-version = "0.10.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "b0fd2260e829bddf4cb6ea802289de2f86d6a7a690192fbe91b3f46e0f2c8473"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
-version = "0.13.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "413ee7dfc52ee1a4949ceeb7dbc8a33f2d6c088194d9f922fb8318faf1f01186"
-dependencies = [
- "either",
-]
-
-[[package]]
-name = "itertools"
 version = "0.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2b192c782037fadd9cfa75548310488aabdbf3d2da73885b31bd0abd03351285"
@@ -1070,22 +1048,20 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1e5bb8c90dca5c87780b3e93863f7ab3df7dfb8a"
+source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
 dependencies = [
  "addr",
  "bigdecimal",
  "bitvec",
- "fxhash",
  "iri-string",
- "itertools 0.10.5",
+ "itertools",
  "lazy_static",
  "percent-encoding",
  "regex",
  "serde",
  "serde_json",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "time",
- "tracing",
  "url",
  "uuid",
 ]
@@ -1123,6 +1099,12 @@ name = "libc"
 version = "0.2.175"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "6a82ae493e598baaea5209805c49bbf2ea7de956d50d7da0da1164f9c6d28543"
+
+[[package]]
+name = "libm"
+version = "0.2.16"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b6d2cec3eae94f9f509c767b45932f1ada8350c4bdb85af2fcab4a3c14807981"
 
 [[package]]
 name = "linux-raw-sys"
@@ -1308,31 +1290,31 @@ dependencies = [
 
 [[package]]
 name = "pbjson"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c7e6349fa080353f4a597daffd05cb81572a9c031a6d4fff7e504947496fcc68"
+checksum = "898bac3fa00d0ba57a4e8289837e965baa2dee8c3749f3b11d45a64b4223d9c3"
 dependencies = [
- "base64 0.21.7",
+ "base64",
  "serde",
 ]
 
 [[package]]
 name = "pbjson-build"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "6eea3058763d6e656105d1403cb04e0a41b7bbac6362d413e7c33be0c32279c9"
+checksum = "af22d08a625a2213a78dbb0ffa253318c5c79ce3133d32d296655a7bdfb02095"
 dependencies = [
  "heck 0.5.0",
- "itertools 0.13.0",
+ "itertools",
  "prost",
  "prost-types",
 ]
 
 [[package]]
 name = "pbjson-types"
-version = "0.7.0"
+version = "0.8.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e54e5e7bfb1652f95bc361d76f3c780d8e526b134b85417e774166ee941f0887"
+checksum = "8e748e28374f10a330ee3bb9f29b828c0ac79831a32bab65015ad9b661ead526"
 dependencies = [
  "bytes",
  "chrono",
@@ -1351,11 +1333,12 @@ checksum = "9b4f627cb1b25917193a259e49bdad08f671f8d9708acfd5fe0a8c1455d87220"
 
 [[package]]
 name = "petgraph"
-version = "0.7.1"
+version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3672b37090dbd86368a4145bc067582552b29c27377cad4e0a306c97f9bd7772"
+checksum = "8701b58ea97060d5e5b155d383a69952a60943f0e6dfe30b04c287beb0b27455"
 dependencies = [
  "fixedbitset",
+ "hashbrown 0.15.5",
  "indexmap 2.11.4",
 ]
 
@@ -1453,9 +1436,9 @@ dependencies = [
 
 [[package]]
 name = "prost"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "2796faa41db3ec313a31f7624d9286acf277b52de526150b7e69f3debf891ee5"
+checksum = "528ac67416ff8646872a3c02cad9cc4ee5dc9f9540c9b10771855c95cb2e5ae1"
 dependencies = [
  "bytes",
  "prost-derive",
@@ -1463,15 +1446,14 @@ dependencies = [
 
 [[package]]
 name = "prost-build"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "be769465445e8c1474e9c5dac2018218498557af32d9ed057325ec9a41ae81bf"
+checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.5.0",
- "itertools 0.14.0",
+ "heck 0.4.1",
+ "itertools",
  "log",
  "multimap",
- "once_cell",
  "petgraph",
  "prettyplease",
  "prost",
@@ -1483,12 +1465,12 @@ dependencies = [
 
 [[package]]
 name = "prost-derive"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8a56d757972c98b346a9b766e3f02746cde6dd1cd1d1d563472929fdd74bec4d"
+checksum = "b570b25f7617e43d59005d0990ccb79e950a423952cea19671b7a876da390adf"
 dependencies = [
  "anyhow",
- "itertools 0.14.0",
+ "itertools",
  "proc-macro2",
  "quote",
  "syn 2.0.106",
@@ -1496,9 +1478,9 @@ dependencies = [
 
 [[package]]
 name = "prost-types"
-version = "0.13.5"
+version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52c2c1bf36ddb1a1c396b3601a3cec27c2462e45f07c386894ec3ccf5332bd16"
+checksum = "f94967dc7688f3054c7fac87473ffae4cc4c3904800e2d9f5b857246d8963b0a"
 dependencies = [
  "prost",
 ]
@@ -1506,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1e5bb8c90dca5c87780b3e93863f7ab3df7dfb8a"
+source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1521,14 +1503,14 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1e5bb8c90dca5c87780b3e93863f7ab3df7dfb8a"
+source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
 dependencies = [
  "bytes",
  "pbjson",
  "pbjson-types",
  "prost",
  "serde",
- "thiserror 1.0.69",
+ "thiserror 2.0.16",
  "uuid",
 ]
 
@@ -1575,9 +1557,9 @@ checksum = "69cdb34c158ceb288df11e18b4bd39de994f6657d83847bdffdbd7f346754b0f"
 
 [[package]]
 name = "radium"
-version = "0.5.3"
+version = "0.7.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "941ba9d78d8e2f7ce474c015eea4d9c6d25b6a3327f9832ee29a4de27f91bbb8"
+checksum = "dc33ff2d4973d518d823d61aa239014831e521c75da58e3df4840d3f47749d09"
 
 [[package]]
 name = "rancor"
@@ -1595,6 +1577,26 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "5407465600fb0548f1442edf71dd20683c6ed326200ace4b1ef0763521bb3b77"
 dependencies = [
  "bitflags 2.9.4",
+]
+
+[[package]]
+name = "ref-cast"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f354300ae66f76f1c85c5f84693f0ce81d747e2c3f21a45fef496d89c960bf7d"
+dependencies = [
+ "ref-cast-impl",
+]
+
+[[package]]
+name = "ref-cast-impl"
+version = "1.0.25"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "b7186006dcb21920990093f30e3dea63b7d6e977bf1256be20c3563a5db070da"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn 2.0.106",
 ]
 
 [[package]]
@@ -1681,7 +1683,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -1703,7 +1705,20 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "3fbf2ae1b8bc8e02df939598064d22402220cd5bbcca1c76f7d6a310974d5615"
 dependencies = [
  "dyn-clone",
- "schemars_derive",
+ "schemars_derive 0.8.22",
+ "serde",
+ "serde_json",
+]
+
+[[package]]
+name = "schemars"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "a2b42f36aa1cd011945615b92222f6bf73c599a102a300334cd7f8dbeec726cc"
+dependencies = [
+ "dyn-clone",
+ "ref-cast",
+ "schemars_derive 1.2.1",
  "serde",
  "serde_json",
 ]
@@ -1713,6 +1728,18 @@ name = "schemars_derive"
 version = "0.8.22"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "32e265784ad618884abaea0600a9adf15393368d840e0222d101a072f3f7534d"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "serde_derive_internals",
+ "syn 2.0.106",
+]
+
+[[package]]
+name = "schemars_derive"
+version = "1.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7d115b50f4aaeea07e79c1912f645c7513d81715d0420f8bc77a18c6260b307f"
 dependencies = [
  "proc-macro2",
  "quote",
@@ -1980,7 +2007,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2234,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#1e5bb8c90dca5c87780b3e93863f7ab3df7dfb8a"
+source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
 dependencies = [
  "memchr",
  "serde_json",
@@ -2294,7 +2321,6 @@ version = "1.18.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2f87b8aa10b915a06587d0dec516c282ff295b475d94abf425d62b57710070a2"
 dependencies = [
- "getrandom",
  "js-sys",
  "serde",
  "wasm-bindgen",
@@ -2453,7 +2479,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.61.0",
+ "windows-sys 0.52.0",
 ]
 
 [[package]]
@@ -2552,15 +2578,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "f2f500e4d28234f72040990ec9d39e3a6b950f9f22d3dba18416c35882612bcb"
 dependencies = [
  "windows-targets 0.53.3",
-]
-
-[[package]]
-name = "windows-sys"
-version = "0.61.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e201184e40b2ede64bc2ea34968b28e33622acdbbf37104f0e4a33f7abe657aa"
-dependencies = [
- "windows-link 0.2.0",
 ]
 
 [[package]]
@@ -2706,9 +2723,12 @@ checksum = "ea2f10b9bb0928dfb1b42b65e1f9e36f7f54dbdf08457afefb38afcdec4fa2bb"
 
 [[package]]
 name = "wyz"
-version = "0.2.0"
+version = "0.5.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "85e60b0d1b5f99db2556934e21937020776a5d31520bf169e851ac44e6420214"
+checksum = "05f360fc0b24296329c78fda852a1e9ae82de9cf7b27dae4b7f62f118f77b9ed"
+dependencies = [
+ "tap",
+]
 
 [[package]]
 name = "yoke"

--- a/airbyte-to-flow/Cargo.toml
+++ b/airbyte-to-flow/Cargo.toml
@@ -24,7 +24,7 @@ clap = { version = "^3", features = ["derive"] }
 futures = "*"
 futures-core = "*"
 futures-util = "*"
-prost = "0.13"
+prost = "0.14"
 schemars = "0.8"
 serde = { version = "*", features = ["derive"] }
 serde_json = { version = "*", features = ["raw_value"] }

--- a/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
+++ b/airbyte-to-flow/src/interceptors/airbyte_source_interceptor.rs
@@ -227,7 +227,7 @@ impl AirbyteSourceInterceptor {
                     .unwrap_or(Vec::new())
                     .iter()
                     .map(|key| {
-                        doc::Pointer::from_iter(key.iter().map(|s| doc::ptr::Token::from_str(&s)))
+                        json::Pointer::from_iter(key.iter().map(|s| json::ptr::Token::from_str(&s)))
                             .to_string()
                     })
                     .collect();

--- a/airbyte-to-flow/src/interceptors/fix_document_schema.rs
+++ b/airbyte-to-flow/src/interceptors/fix_document_schema.rs
@@ -1,4 +1,4 @@
-use doc::ptr::Token;
+use json::ptr::Token;
 use json::schema::formats::Format;
 use serde_json::json;
 
@@ -13,13 +13,13 @@ pub fn fix_document_schema_keys(
 ) -> Result<serde_json::Value, Error> {
     let original = doc.clone();
     for key in key_ptrs {
-        let ptr = doc::Pointer::from_str(&key);
+        let ptr = json::Pointer::from_str(&key);
 
-        let mut current = doc::Pointer::empty();
+        let mut current = json::Pointer::empty();
         for token in ptr.iter() {
             match token {
                 // Add "minItems" to arrays to ensure the key is always available at that index
-                doc::ptr::Token::Index(idx) => {
+                json::ptr::Token::Index(idx) => {
                     /* TODO: This code can have ambiguous results when encountering integer-like
                      * properties, and as such has been disabled for now.
                      * See https://github.com/estuary/airbyte/pull/46#discussion_r992250679
@@ -40,7 +40,7 @@ pub fn fix_document_schema_keys(
                     )));
                 }
                 // Add "required" and ensure the property and its parent's type do not include null
-                doc::ptr::Token::Property(prop) => {
+                json::ptr::Token::Property(prop) => {
                     let mut parent_map = doc
                         .pointer_mut(&current.to_string())
                         .unwrap()
@@ -125,13 +125,13 @@ pub fn fix_document_schema_keys(
                     current.push(Token::Property("properties".to_string()));
                     current.push(Token::Property(prop.to_string()));
                 }
-                doc::ptr::Token::NextIndex => {
+                json::ptr::Token::NextIndex => {
                     return Err(Error::InvalidSchema(format!(
                     "cannot use JSONPointer next index pointer /-/ in key pointer at {:?} in {:?}",
                     current, original
                 )))
                 }
-                doc::ptr::Token::NextProperty => {
+                json::ptr::Token::NextProperty => {
                     return Err(Error::InvalidSchema(format!(
                         "cannot use JSONPointer NextToken(/*/) in key pointer at {:?} in {:?}",
                         current, original

--- a/airbyte-to-flow/src/interceptors/normalize.rs
+++ b/airbyte-to-flow/src/interceptors/normalize.rs
@@ -1,9 +1,8 @@
 use crate::interceptors::fix_document_schema::traverse_jsonschema;
 use dateparser::parse_with;
 use chrono::{SecondsFormat, LocalResult, TimeZone, NaiveTime};
-use doc::ptr::Token;
+use json::ptr::Token;
 use json::schema::formats::Format;
-use json::validator::ValidationResult;
 use regex::Regex;
 use serde::Deserialize;
 use serde_json::Map;
@@ -29,7 +28,7 @@ pub fn normalize_doc(
         for entry in entries {
             match entry.normalization {
                 Normalization::DatetimeToDate => {
-                    normalize_datetime_to_date(doc, &doc::Pointer::from_str(&entry.pointer))
+                    normalize_datetime_to_date(doc, &json::Pointer::from_str(&entry.pointer))
                 }
             }
         }
@@ -42,7 +41,7 @@ pub fn automatic_normalizations(
 ) {
     traverse_jsonschema(schema, &mut |map: &mut Map<String, serde_json::Value>, ptr: &str| {
         if map.get("format").and_then(|f| f.as_str()) == Some("date-time") {
-            let pointer = doc::Pointer::from_str(ptr);
+            let pointer = json::Pointer::from_str(ptr);
 
             // traverse_jsonschema writes a /*/ pointer for array items. Here we check for such a star in the pointer
             // and expand it to normalize every item of the array. This implementation is kind of gross. Ideally we would have traverse_jsonschema
@@ -50,7 +49,7 @@ pub fn automatic_normalizations(
             let star_split = pointer.0.rsplit(|item| item == &Token::Property("*".to_string())).collect::<Vec<_>>();
             if star_split.len() > 1 {
                 let property_in_item = &star_split[0][0];
-                let array_parent = doc::Pointer(star_split[1].to_vec());
+                let array_parent = json::Pointer(star_split[1].to_vec());
 
                 array_parent.query(&doc.clone()).map(|val| {
                     val.as_array().map(|arr| {
@@ -75,29 +74,27 @@ pub fn automatic_normalizations(
 // and we will not be able to support seconds unix timestamps after January 1st, 30000
 const UNIX_SECONDS_MAX: i64 = 32503680000;
 
-fn normalize_to_rfc3339(doc: &mut serde_json::Value, ptr: &doc::Pointer) {
+fn normalize_to_rfc3339(doc: &mut serde_json::Value, ptr: &json::Pointer) {
     if let Some(val) = ptr.query(doc) {
         match val.to_owned() {
             serde_json::Value::String(val) => {
-                match Format::DateTime.validate(&val) {
-                    ValidationResult::Valid => (), // Already a valid date
-                    _ => {
-                        let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
+                if !Format::DateTime.validate(&val) {
+                    // Not already a valid date
+                    let midnight_naive = NaiveTime::from_hms_opt(0, 0, 0).unwrap();
 
-                        let parsed = parse_with(&val, &chrono::offset::Utc, midnight_naive).or_else(|_|
-                            chrono::DateTime::parse_from_str(&val, "%Y-%m-%dT%H:%M:%S%.3f%z").map(|d| d.with_timezone(&chrono::Utc))
-                        ).or_else(|_|
-                            chrono::DateTime::parse_from_str(&val, "%Y-%m-%dT%H:%M:%S%z").map(|d| d.with_timezone(&chrono::Utc))
-                        ).or_else(|_|
-                            chrono::NaiveDateTime::parse_from_str(&val, "%Y-%m-%dT%H:%M:%S%.3f").map(|d| d.and_local_timezone(chrono::Utc).unwrap())
-                        );
-                        if let Ok(parsed) = parsed {
-                            let formatted = parsed.to_rfc3339_opts(SecondsFormat::AutoSi, true);
-                                ptr.create_value(doc)
-                                .map(|v| *v = serde_json::json!(formatted.as_str()));
-                        }
+                    let parsed = parse_with(&val, &chrono::offset::Utc, midnight_naive).or_else(|_|
+                        chrono::DateTime::parse_from_str(&val, "%Y-%m-%dT%H:%M:%S%.3f%z").map(|d| d.with_timezone(&chrono::Utc))
+                    ).or_else(|_|
+                        chrono::DateTime::parse_from_str(&val, "%Y-%m-%dT%H:%M:%S%z").map(|d| d.with_timezone(&chrono::Utc))
+                    ).or_else(|_|
+                        chrono::NaiveDateTime::parse_from_str(&val, "%Y-%m-%dT%H:%M:%S%.3f").map(|d| d.and_local_timezone(chrono::Utc).unwrap())
+                    );
+                    if let Ok(parsed) = parsed {
+                        let formatted = parsed.to_rfc3339_opts(SecondsFormat::AutoSi, true);
+                            json::ptr::create_value(ptr, doc)
+                            .map(|v| *v = serde_json::json!(formatted.as_str()));
                     }
-                };    
+                }
             },
             serde_json::Value::Number(raw_num) => {
                 let v = if raw_num.is_f64() {
@@ -115,7 +112,7 @@ fn normalize_to_rfc3339(doc: &mut serde_json::Value, ptr: &doc::Pointer) {
                 match chrono::Utc.timestamp_opt(seconds_since_epoch, nanoseconds) {
                     LocalResult::Single(dt) => {
                         let formatted = dt.to_rfc3339_opts(SecondsFormat::AutoSi, true);
-                        ptr.create_value(doc)
+                        json::ptr::create_value(ptr, doc)
                         .map(|val| *val = serde_json::json!(formatted.as_str()));
                     },
                     _ => {}
@@ -133,18 +130,16 @@ lazy_static::lazy_static! {
         Regex::new(r"^[0-9]{4}-[0-9]{2}-[0-9]{2}").expect("Is a valid regex");
 }
 
-fn normalize_datetime_to_date(doc: &mut serde_json::Value, ptr: &doc::Pointer) {
+fn normalize_datetime_to_date(doc: &mut serde_json::Value, ptr: &json::Pointer) {
     if let Some(val) = ptr.query(doc) {
         val.to_owned().as_str().map(|v| {
-            match Format::Date.validate(v) {
-                ValidationResult::Valid => (), // Already a valid date
-                _ => {
-                    EXTRACT_DATE_RE.find(v).map(|mat| {
-                        ptr.create_value(doc)
-                            .map(|val| *val = serde_json::json!(mat.as_str()))
-                    });
-                }
-            };
+            if !Format::Date.validate(v) {
+                // Not already a valid date
+                EXTRACT_DATE_RE.find(v).map(|mat| {
+                    json::ptr::create_value(ptr, doc)
+                        .map(|val| *val = serde_json::json!(mat.as_str()))
+                });
+            }
         });
     }
 }

--- a/airbyte-to-flow/src/interceptors/remap.rs
+++ b/airbyte-to-flow/src/interceptors/remap.rs
@@ -7,17 +7,16 @@ use crate::errors::Error;
 pub fn remap(doc: &mut serde_json::Value, mapping: &serde_json::Value) -> Result<(), Error> {
     let doc_copy = doc.clone();
     for (key, value) in mapping.as_object().unwrap() {
-        let key_ptr = doc::Pointer::from_str(&key);
+        let key_ptr = json::Pointer::from_str(&key);
         let value_str = value.as_str().ok_or(Error::InvalidMapping(format!(
             "expected {} key to have a string value",
             key
         )))?;
-        let value_ptr = doc::Pointer::from_str(value_str);
+        let value_ptr = json::Pointer::from_str(value_str);
 
         // copy from "value" pointer to "key" pointer
         if key != "" {
-            let location = key_ptr
-                .create_value(doc)
+            let location = json::ptr::create_value(&key_ptr, doc)
                 .ok_or(Error::InvalidMapping(format!(
                     "could not query {} in document",
                     key
@@ -41,9 +40,8 @@ pub fn remap(doc: &mut serde_json::Value, mapping: &serde_json::Value) -> Result
                     "could not split {} to parent and child",
                     value_str
                 )))?;
-        let value_parent_ptr = doc::Pointer::from_str(value_parent_str);
-        let parent = value_parent_ptr
-            .create_value(doc)
+        let value_parent_ptr = json::Pointer::from_str(value_parent_str);
+        let parent = json::ptr::create_value(&value_parent_ptr, doc)
             .ok_or(Error::InvalidMapping(format!(
                 "could not find {} in document",
                 value_parent_str

--- a/airbyte-to-flow/src/libs/json.rs
+++ b/airbyte-to-flow/src/libs/json.rs
@@ -1,4 +1,4 @@
-use doc::ptr::Pointer;
+use json::ptr::Pointer;
 use schemars::{schema::RootSchema, JsonSchema};
 
 // Create the RootSchema given datatype T.


### PR DESCRIPTION
Bumps the Flow git dependencies to the latest revision and adapts to the new `json` crate API introduced in https://github.com/estuary/flow/pull/2421:

- Pointer types moved from the `doc` crate to `json` (`json::Pointer`, `json::ptr::Token`), and `create_value` is now the free function `json::ptr::create_value`.
- `Format::validate` now returns `bool` instead of `ValidationResult`.

Realigns transitive deps with what Flow pins: 
- `prost` `0.13` -> `0.14`
- `pbjson` `0.7` -> `0.8`
- `bigdecimal` `0.3` -> `0.4`