### PR TITLE
airbyte-to-flow: Update Flow version pin

### DIFF
--- a/airbyte-to-flow/Cargo.lock
+++ b/airbyte-to-flow/Cargo.lock
@@ -540,7 +540,7 @@ dependencies = [
 [[package]]
 name = "doc"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
+source = "git+https://github.com/estuary/flow#a292a893d92f967f1ccbf983b9e653a2ad3cc2b3"
 dependencies = [
  "base64",
  "bigdecimal",
@@ -597,7 +597,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -621,7 +621,7 @@ checksum = "1d674e81391d1e1ab681a28d99df07927c6d4aa5b027d7da16ba32d1d21ecd99"
 [[package]]
 name = "flow_cli_common"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
+source = "git+https://github.com/estuary/flow#a292a893d92f967f1ccbf983b9e653a2ad3cc2b3"
 dependencies = [
  "anyhow",
  "atty",
@@ -1048,7 +1048,7 @@ dependencies = [
 [[package]]
 name = "json"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
+source = "git+https://github.com/estuary/flow#a292a893d92f967f1ccbf983b9e653a2ad3cc2b3"
 dependencies = [
  "addr",
  "bigdecimal",
@@ -1450,7 +1450,7 @@ version = "0.14.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "03da047801ff44bb6a4d407d4860c05fd70bb81714e6b2f3812603d5b145b042"
 dependencies = [
- "heck 0.4.1",
+ "heck 0.5.0",
  "itertools",
  "log",
  "multimap",
@@ -1488,7 +1488,7 @@ dependencies = [
 [[package]]
 name = "proto-flow"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
+source = "git+https://github.com/estuary/flow#a292a893d92f967f1ccbf983b9e653a2ad3cc2b3"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1503,7 +1503,7 @@ dependencies = [
 [[package]]
 name = "proto-gazette"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
+source = "git+https://github.com/estuary/flow#a292a893d92f967f1ccbf983b9e653a2ad3cc2b3"
 dependencies = [
  "bytes",
  "pbjson",
@@ -1683,7 +1683,7 @@ dependencies = [
  "errno",
  "libc",
  "linux-raw-sys",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2007,7 +2007,7 @@ dependencies = [
  "getrandom",
  "once_cell",
  "rustix",
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -2261,7 +2261,7 @@ dependencies = [
 [[package]]
 name = "tuple"
 version = "0.0.0"
-source = "git+https://github.com/estuary/flow#9396064d7ed0123b041284c78c489e2b56bc73bf"
+source = "git+https://github.com/estuary/flow#a292a893d92f967f1ccbf983b9e653a2ad3cc2b3"
 dependencies = [
  "memchr",
  "serde_json",
@@ -2479,7 +2479,7 @@ version = "0.1.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "c2a7b1c03c876122aa43f3020e6c3c3ee5c05081c9a00739faf7503aeba10d22"
 dependencies = [
- "windows-sys 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]


### PR DESCRIPTION
Part of https://github.com/estuary/flow/issues/2985, we need all connectors to have picked up the "tolerate unknown fields" change from Flow commit 184db0e before merging https://github.com/estuary/flow/pull/3119 which introduces a new sealed endpoint config property to the Open RPCs.

As far as I'm aware everything else either has this change or didn't need it, but airbyte-to-flow connectors still need it.