### PR TITLE
source-amazon-ads: Add secret annotation to refresh_token

### DIFF
--- a/airbyte-integrations/connectors/source-amazon-ads/spec.patch.json
+++ b/airbyte-integrations/connectors/source-amazon-ads/spec.patch.json
@@ -51,6 +51,7 @@
                         "refresh_token": {
                             "type": "string",
                             "title": "Refresh token",
+                            "airbyte_secret": true,
                             "description": "The key to refresh the expired access token."
                         }
                     }


### PR DESCRIPTION
The refresh token is the customer's own OAuth credential used to mint their access tokens, so it should be annotated as secret like the sibling client_id and client_secret fields already are.

I believe this is trivially backwards-compatible, since runtime decryption collapses `"foobar"` and `"foobar_sops"` values together and isn't too picky about which form was present in the encrypted config or whether that lines up with the schema annotations.